### PR TITLE
Phase 1 — Shared AI infrastructure (Openrouter + Ontoserver tools + agent loop)

### DIFF
--- a/eRequest-placer-AI/PLAN.md
+++ b/eRequest-placer-AI/PLAN.md
@@ -58,7 +58,10 @@ Build the substrate before any feature UI lands. Add to [./config.js](./config.j
 ```js
 export const AI_DEFAULTS = {
   OPENROUTER_BASE: 'https://openrouter.ai/api/v1',
-  OPENROUTER_MODEL: 'anthropic/claude-sonnet-4-5',
+  // Free model chosen for initial dev; runtime-swappable via the AI Settings
+  // panel. If tool-calling proves unreliable, try anthropic/claude-haiku-4-5
+  // or openai/gpt-4o-mini.
+  OPENROUTER_MODEL: 'google/gemma-4-31b-it:free',
   MCP_URL: 'https://ontoserver.app/mcp',
   REST_TX_BASE: 'https://tx.dev.hl7.org.au/fhir',
   REASON_ECL: '< 404684003 |Clinical finding|',
@@ -171,7 +174,9 @@ New modules under [./modules/](./modules/):
 ## Risks & unknowns
 
 1. **MCP CORS at `https://ontoserver.app/mcp`** — the fallback handles failure transparently. The boot banner surfaces which backend is live.
-2. **Model identifier** — `anthropic/claude-sonnet-4-5` is the spec default. Settings allow runtime swap. Verify availability on Openrouter at build time.
+2. **Model identifier** — Spec §3.1 lists `anthropic/claude-sonnet-4-5` as the suggested default with "developer to confirm at build time"; this plan's actual chosen default is `google/gemma-4-31b-it:free`. Free-tier rate limits (~50 req/day without credits) and Gemma's historical tool-calling reliability are the two things to watch. Settings allow runtime swap.
+
+3. **API key storage** — Client-side localStorage, **not** GitHub Secrets. The app is a static page with no server runtime, so secrets injected at build time would be visible in the deployed JS (and would burn the deployer's credits on every visitor). Each user supplies their own key via the settings panel; risk posture matches the existing FHIR auth tokens (spec §3.1, §9, §9.1).
 3. **MCP tool names** — spec assumes `search_concepts` / `lookup_concept`. `listTools()` at probe time should confirm; if Ontoserver MCP names differ, translate inside `ontoserver-mcp.js` keeping the unified surface.
 4. **Agent JSON output reliability** — defensive extractor handles fences and stray prose; surface true parse failure as the empty/error state per spec §4.7.
 5. **`_sort=-authored` server support** — fall back to `-_lastUpdated` once if rejected.

--- a/eRequest-placer-AI/PLAN.md
+++ b/eRequest-placer-AI/PLAN.md
@@ -8,7 +8,7 @@
 
 ## Context
 
-The callistemon repo hosts a suite of static, GitHub-Pages-deployed FHIR demo apps under `https://callistemon.site/`. The flagship [eRequest-placer/](../eRequest-placer/) lets a clinician build an AU eRequesting FHIR Transaction Bundle (Patient + Encounter + group Task + per-test Task + ServiceRequests + optional pregnancy Observation) and POST it to a configurable FHIR server.
+The callistemon repo hosts a suite of static, GitHub-Pages-deployed FHIR demo apps under `https://mattcordell.github.io/callistemon/` (the unrelated `callistemon.site` referenced in module configs is the FHIR server backend, not the Pages site). The flagship [eRequest-placer/](../eRequest-placer/) lets a clinician build an AU eRequesting FHIR Transaction Bundle (Patient + Encounter + group Task + per-test Task + ServiceRequests + optional pregnancy Observation) and POST it to a configurable FHIR server.
 
 The product spec calls for a **sister app at [./](./) (`eRequest-placer-AI/`)** that retains every behaviour of the original and layers three AI enhancements on top:
 
@@ -18,7 +18,7 @@ The product spec calls for a **sister app at [./](./) (`eRequest-placer-AI/`)** 
 
 All three features share one AI pipeline: an Openrouter chat-completions call (OpenAI-compatible) that uses Ontoserver-backed `search_concepts` / `lookup_concept` tools, ECL-scoped per feature, with an accuracy-over-completeness principle.
 
-The original `eRequest-placer` stays unchanged as the reference implementation. The new app deploys to `https://callistemon.site/eRequest-placer-AI/` as a self-contained static directory.
+The original `eRequest-placer` stays unchanged as the reference implementation. The new app deploys to `https://mattcordell.github.io/callistemon/eRequest-placer-AI/` as a self-contained static directory.
 
 ---
 

--- a/eRequest-placer-AI/PLAN.md
+++ b/eRequest-placer-AI/PLAN.md
@@ -57,11 +57,21 @@ Build the substrate before any feature UI lands. Add to [./config.js](./config.j
 
 ```js
 export const AI_DEFAULTS = {
+  // Default route: managed Cloudflare Worker proxy that holds the OpenRouter
+  // API key as a secret. Visitors don't need their own key. Replaced with the
+  // real deployed worker URL once the proxy lands (see "OpenRouter proxy"
+  // issue).
+  PROXY_BASE_URL: 'https://callistemon-ai-proxy.workers.dev',
+  // Fallback route: direct OpenRouter, used only when the user flips the
+  // "Use my own OpenRouter key" toggle in settings.
   OPENROUTER_BASE: 'https://openrouter.ai/api/v1',
   // Free model chosen for initial dev; runtime-swappable via the AI Settings
   // panel. If tool-calling proves unreliable, try anthropic/claude-haiku-4-5
   // or openai/gpt-4o-mini.
   OPENROUTER_MODEL: 'google/gemma-4-31b-it:free',
+  // Hybrid key handling: default false → proxy. When true, OPENROUTER_API_KEY
+  // is read from settings and sent direct to OPENROUTER_BASE.
+  USE_OWN_OPENROUTER_KEY: false,
   MCP_URL: 'https://ontoserver.app/mcp',
   REST_TX_BASE: 'https://tx.dev.hl7.org.au/fhir',
   REASON_ECL: '< 404684003 |Clinical finding|',
@@ -75,8 +85,8 @@ export const AI_DEFAULTS = {
 
 New modules under [./modules/](./modules/):
 
-- **`settings-ai.js`** — localStorage-backed `getAiSettings()` / `setAiSetting()` over `AI_DEFAULTS`. Extends the existing `#server-panel` popout with an "AI Settings" `<details>` block (do not introduce a new floating button). API key, model, two ECLs, pre-prompt supplements, guidelines summary, two toggle checkboxes. Document API-key risk in a JSDoc comment. Fires `CustomEvent('ai-enabled-changed')` on toggle.
-- **`openrouter-client.js`** — `chatCompletion({ model, messages, tools, signal })` → POST to `${OPENROUTER_BASE}/chat/completions`, OpenAI-format response. Non-streaming. Headers include `Authorization: Bearer <key>`, `HTTP-Referer`, `X-Title`. One retry on 429/5xx. `setDebugUrl(url)` before fetch so calls appear in the existing debug panel.
+- **`settings-ai.js`** — localStorage-backed `getAiSettings()` / `setAiSetting()` over `AI_DEFAULTS`. Extends the existing `#server-panel` popout with an "AI Settings" `<details>` block (do not introduce a new floating button). Settings UI: model dropdown, two ECLs, pre-prompt supplements, guidelines summary, master AI toggle, decision-support toggle, **"Use my own OpenRouter key" checkbox** — when checked, reveals an API key field (`<input type="password">`) and disables the proxy route. JSDoc on top of the file: in default mode no client-side key, no exposure; in override mode the key is in localStorage with the same risk posture as the existing FHIR auth tokens. Fires `CustomEvent('ai-enabled-changed')` on toggle.
+- **`openrouter-client.js`** — `chatCompletion({ model, messages, tools, signal })` → POST to either `${PROXY_BASE_URL}/chat/completions` (default — proxy adds the auth header) or `${OPENROUTER_BASE}/chat/completions` with `Authorization: Bearer <userKey>` (when `USE_OWN_OPENROUTER_KEY` is true). The choice is made per-call by reading current settings, so flipping the toggle takes effect immediately without reload. OpenAI-format response either way. Common headers: `HTTP-Referer`, `X-Title`. Non-streaming. One retry on 429/5xx. `setDebugUrl(url)` before fetch so calls appear in the existing debug panel.
 - **`ontoserver-mcp.js`** — `class McpClient` with `initialize()`, `listTools()`, `callTool(name, args)`; JSON-RPC over POST, captures `Mcp-Session-Id`. Handles both `application/json` and `text/event-stream` responses (parse last `data:` event). Exports `probeMcp(url, timeoutMs)` (returns boolean), plus `searchConcepts({query, valueSetEcl, count})` and `lookupConcept({system, code})` normalised to `{code, display, system}[]`. Throws `McpTransportError` on any failure so the wrapper can fall back. `setDebugUrl` on every POST.
 - **`ontoserver-rest.js`** — identical surface, REST backend. `searchConcepts` uses `${REST_TX_BASE}/ValueSet/$expand?url=http://snomed.info/sct?fhir_vs=ecl/{ecl}&filter={q}&count={n}&includeDesignations=true`; `lookupConcept` uses `${REST_TX_BASE}/CodeSystem/$lookup?system=…&code=…`. Maps `expansion.contains` → `{code, display, system}`. Surface `OperationOutcome.diagnostics` on errors. The expand pattern is already used in [../eRequest-placer/modules/terminology.js](../eRequest-placer/modules/terminology.js) — reuse it.
 - **`ontoserver-tools.js`** — `initOntoserverBackend()` runs `probeMcp` at boot, stores `backend = 'mcp' | 'rest'`. Exposes the unified `searchConcepts` / `lookupConcept` (delegates; on first MCP failure during a call, sticky-fall-back to REST). Exports `getTools()` returning OpenAI tool descriptors with names `search_concepts` and `lookup_concept` (snake_case, matching spec §3.2). `getActiveBackendName()` for the debug banner.
@@ -84,7 +94,9 @@ New modules under [./modules/](./modules/):
 
 **Manual test harness:** add a `#ai-test-harness` block in `index.html`, revealed only by `?aitest=1`. Buttons that exercise `searchConcepts` and `runAgent` end-to-end. Used during phases 1–4; left behind the `?aitest=1` gate at the end.
 
-**Verify:** open `?aitest=1`, set Openrouter key in settings, click both test buttons. Confirm: an Openrouter POST in DevTools, MCP POSTs (or REST GETs) interleaved with tool_call responses, all URLs land in the debug panel, `getActiveBackendName()` matches reality. Force REST by setting a temporary localStorage flag and re-test.
+**Verify:** open `?aitest=1`, click both test buttons. By default the requests should go to `PROXY_BASE_URL` and the proxy adds the auth header upstream — confirm via DevTools Network. Then flip "Use my own OpenRouter key" in settings, paste a personal key, re-run — requests should now go direct to `OPENROUTER_BASE` with `Authorization: Bearer …` visible in the outbound headers. Confirm: MCP POSTs (or REST GETs) interleaved with tool_call responses, all URLs land in the debug panel, `getActiveBackendName()` matches reality. Force REST by setting a temporary localStorage flag and re-test.
+
+> **Proxy prerequisite for "default mode"**: the Cloudflare Worker tracked in the [OpenRouter proxy](../tree/main/eRequest-placer-AI/PLAN.md) issue must be deployed before the proxy route works end-to-end. Phase 1 can be developed and verified using the "Use my own key" override path without the worker.
 
 ---
 
@@ -176,12 +188,15 @@ New modules under [./modules/](./modules/):
 1. **MCP CORS at `https://ontoserver.app/mcp`** — the fallback handles failure transparently. The boot banner surfaces which backend is live.
 2. **Model identifier** — Spec §3.1 lists `anthropic/claude-sonnet-4-5` as the suggested default with "developer to confirm at build time"; this plan's actual chosen default is `google/gemma-4-31b-it:free`. Free-tier rate limits (~50 req/day without credits) and Gemma's historical tool-calling reliability are the two things to watch. Settings allow runtime swap.
 
-3. **API key storage** — Client-side localStorage, **not** GitHub Secrets. The app is a static page with no server runtime, so secrets injected at build time would be visible in the deployed JS (and would burn the deployer's credits on every visitor). Each user supplies their own key via the settings panel; risk posture matches the existing FHIR auth tokens (spec §3.1, §9, §9.1).
-3. **MCP tool names** — spec assumes `search_concepts` / `lookup_concept`. `listTools()` at probe time should confirm; if Ontoserver MCP names differ, translate inside `ontoserver-mcp.js` keeping the unified surface.
-4. **Agent JSON output reliability** — defensive extractor handles fences and stray prose; surface true parse failure as the empty/error state per spec §4.7.
-5. **`_sort=-authored` server support** — fall back to `-_lastUpdated` once if rejected.
-6. **`file://` no longer works** — locked ES6-modules decision. Document in README.
-7. **Ack-note placement** — appended to every ServiceRequest's `note[]` in the bundle. Flag if a different convention (single SR, Provenance) is preferred.
+3. **API key storage (hybrid)** — Two routes by design:
+   - **Default**: client calls a managed Cloudflare Worker proxy that holds the OpenRouter API key as a secret env var (`OPENROUTER_API_KEY`). The browser never sees the key. The deployer pays for usage; per-IP rate limiting and origin allowlist on the proxy bound abuse. See the "OpenRouter proxy" deployment issue for the worker template and setup steps.
+   - **Override**: a "Use my own OpenRouter key" toggle in settings switches `openrouter-client.js` to call OpenRouter directly with a user-supplied key from localStorage. Risk posture for that key matches the existing FHIR auth tokens (spec §3.1, §9, §9.1).
+   - GitHub Secrets are **not** a fit on either route: the static page has no server runtime, and baking the key into the deployed JS at build time would expose it in DevTools and burn credits on every visitor.
+4. **MCP tool names** — spec assumes `search_concepts` / `lookup_concept`. `listTools()` at probe time should confirm; if Ontoserver MCP names differ, translate inside `ontoserver-mcp.js` keeping the unified surface.
+5. **Agent JSON output reliability** — defensive extractor handles fences and stray prose; surface true parse failure as the empty/error state per spec §4.7.
+6. **`_sort=-authored` server support** — fall back to `-_lastUpdated` once if rejected.
+7. **`file://` no longer works** — locked ES6-modules decision. Document in README.
+8. **Ack-note placement** — appended to every ServiceRequest's `note[]` in the bundle. Flag if a different convention (single SR, Provenance) is preferred.
 
 ---
 

--- a/eRequest-placer-AI/app.js
+++ b/eRequest-placer-AI/app.js
@@ -31,6 +31,14 @@ import {
   initAuthFetch, maybePromptPasswordFor, initAuthManage,
   initQrModal, initSendButton,
 } from './modules/server.js';
+import {
+  getAiSettings, initAiSettingsPanel,
+} from './modules/settings-ai.js';
+import {
+  initOntoserverBackend, getActiveBackendName,
+  searchConcepts, lookupConcept, getTools,
+} from './modules/ontoserver-tools.js';
+import { runAgent } from './modules/ai-agent.js';
 
 // JSON viewer instance — owned by this module (boot sets it). Domain modules
 // like bundle-builder.js are no longer aware of it; the caller of buildBundle()
@@ -43,6 +51,64 @@ function updateSpecialtyDisplay(name) {
   const text = sp ? ('Specialty: ' + sp.display) : '';
   el.textContent = text;
   if (text) el.classList.remove('hidden'); else el.classList.add('hidden');
+}
+
+// Manual test harness for the shared AI substrate (revealed by ?aitest=1).
+// Exercises the Ontoserver tool surface and the agent loop without any feature
+// UI. Stays behind the gate through phases 2-4.
+function initAiTestHarness() {
+  const section = document.getElementById('ai-test-harness');
+  if (!section) return;
+  section.classList.remove('hidden');
+
+  const out = document.getElementById('ai-test-output');
+  const searchBtn = document.getElementById('ai-test-search');
+  const agentBtn = document.getElementById('ai-test-agent');
+
+  const print = (label, data) => {
+    const body = (typeof data === 'string') ? data : JSON.stringify(data, null, 2);
+    out.textContent = label + '\n\n' + body;
+  };
+
+  searchBtn.addEventListener('click', async () => {
+    searchBtn.classList.add('btn-disabled');
+    out.textContent = 'Running search test…';
+    try {
+      const res = await searchConcepts({ query: 'diabetes', valueSetEcl: '< 404684003' });
+      print('search_concepts → backend=' + getActiveBackendName() + ', count=' + res.length, res);
+    } catch (e) {
+      print('Search test failed', String((e && e.message) || e));
+    } finally {
+      searchBtn.classList.remove('btn-disabled');
+    }
+  });
+
+  agentBtn.addEventListener('click', async () => {
+    agentBtn.classList.add('btn-disabled');
+    out.textContent = 'Running agent test… (makes OpenRouter calls)';
+    const tools = getTools();
+    const toolImpl = {
+      search_concepts: (args) => searchConcepts(args),
+      lookup_concept: (args) => lookupConcept(args),
+    };
+    try {
+      const result = await runAgent({
+        systemPrompt: "Return JSON array of SNOMED codes for 'type 2 diabetes mellitus'. Use search_concepts to verify.",
+        userMessage: 'type 2 diabetes mellitus',
+        tools,
+        toolImpl,
+        model: getAiSettings().OPENROUTER_MODEL,
+      });
+      const summary = 'runAgent → backend=' + getActiveBackendName()
+        + (result.error ? (', error=' + result.error) : '')
+        + ', transcript turns=' + result.transcript.length;
+      print(summary, result.parsed != null ? result.parsed : (result.finalContent || '(no content)'));
+    } catch (e) {
+      print('Agent test failed', String((e && e.message) || e));
+    } finally {
+      agentBtn.classList.remove('btn-disabled');
+    }
+  });
 }
 
 function boot() {
@@ -86,6 +152,22 @@ function boot() {
     if (toggle) toggle.addEventListener('click', () => panel.classList.toggle('hidden'));
     if (close) close.addEventListener('click', () => panel.classList.add('hidden'));
   }
+
+  // ----- AI settings panel (extends #server-panel; no new floating button) -----
+  initAiSettingsPanel();
+
+  // ----- Ontoserver backend probe + one-line debug banner (backend + model) -----
+  (async () => {
+    let backend = 'unknown';
+    try { backend = await initOntoserverBackend(); } catch (_e) { backend = 'rest'; }
+    const banner = document.getElementById('ai-backend-banner');
+    if (banner) {
+      banner.textContent = 'AI: Ontoserver backend = ' + backend + ' · model = ' + getAiSettings().OPENROUTER_MODEL;
+    }
+  })();
+
+  // ----- AI test harness (revealed only by ?aitest=1) -----
+  if (location.search.includes('aitest=1')) initAiTestHarness();
 
   // ----- Server preset handlers -----
   {

--- a/eRequest-placer-AI/config.js
+++ b/eRequest-placer-AI/config.js
@@ -61,3 +61,39 @@ export const CAT = {
   PATH: { coding: [{ system: 'http://snomed.info/sct', code: '108252007', display: 'Laboratory procedure' }] },
   IMAG: { coding: [{ system: 'http://snomed.info/sct', code: '363679005', display: 'Imaging' }] },
 };
+
+// ----- AI infrastructure defaults (Phase 1, spec §3, §6, §7) -----
+// These seed the localStorage-backed AI settings store (modules/settings-ai.js).
+// getAiSettings() returns { ...AI_DEFAULTS, ...storedOverrides } on every read,
+// so editing a default here propagates unless the user has overridden that key.
+export const AI_DEFAULTS = {
+  // Default route: managed Cloudflare Worker proxy that holds the OpenRouter API
+  // key as a secret. Visitors don't need their own key. Replace this placeholder
+  // with the real deployed worker URL once the proxy issue is closed.
+  PROXY_BASE_URL: 'https://callistemon-ai-proxy.workers.dev',
+  // Fallback route: direct OpenRouter, used only when USE_OWN_OPENROUTER_KEY is
+  // true (the "Use my own OpenRouter key" toggle in AI Settings).
+  OPENROUTER_BASE: 'https://openrouter.ai/api/v1',
+  // Free model chosen for initial dev; runtime-swappable via the AI Settings
+  // panel. If tool-calling proves unreliable, try anthropic/claude-haiku-4-5
+  // or openai/gpt-4o-mini.
+  OPENROUTER_MODEL: 'google/gemma-4-31b-it:free',
+  // Hybrid key handling: default false -> proxy route. When true, the user's own
+  // key (OPENROUTER_API_KEY) is read from settings and sent direct to OPENROUTER_BASE.
+  USE_OWN_OPENROUTER_KEY: false,
+  // Ontoserver: MCP first, REST fallback (probed at boot in ontoserver-tools.js).
+  MCP_URL: 'https://ontoserver.app/mcp',
+  REST_TX_BASE: 'https://tx.dev.hl7.org.au/fhir',
+  // Per-feature ECL scoping (spec §7). Feature A draws from clinical findings,
+  // Feature B from procedures.
+  REASON_ECL: '< 404684003 |Clinical finding|',
+  TEST_ECL: '< 71388002 |Procedure|',
+  // Operator-tunable prompt context (spec §5.4, §C.4).
+  PRE_PROMPT_SUPPLEMENTS: 'When a pathology specimen type is not specified, prefer serum, then blood, then urine (in that order).',
+  GUIDELINES_SUMMARY: '',
+  // Feature toggles (spec §6, §C.11).
+  AI_FEATURES_ENABLED: true,
+  DECISION_SUPPORT_ENABLED: true,
+};
+
+export const AI_SETTINGS_KEY = 'callistemon_ai_settings';

--- a/eRequest-placer-AI/config.js
+++ b/eRequest-placer-AI/config.js
@@ -71,12 +71,19 @@ export const AI_DEFAULTS = {
   // key as a secret. Visitors don't need their own key. Replace this placeholder
   // with the real deployed worker URL once the proxy issue is closed.
   PROXY_BASE_URL: 'https://callistemon-ai-proxy.workers.dev',
+  // Guard: the host above is an UNCLAIMED workers.dev placeholder until issue #20
+  // deploys the worker. While false, openrouter-client refuses the proxy route
+  // (it would POST clinical free-text to an unowned domain) and tells the user to
+  // switch on their own key. Flip to true when #20 ships the real URL.
+  PROXY_DEPLOYED: false,
   // Fallback route: direct OpenRouter, used only when USE_OWN_OPENROUTER_KEY is
   // true (the "Use my own OpenRouter key" toggle in AI Settings).
   OPENROUTER_BASE: 'https://openrouter.ai/api/v1',
   // Free model chosen for initial dev; runtime-swappable via the AI Settings
-  // panel. If tool-calling proves unreliable, try anthropic/claude-haiku-4-5
-  // or openai/gpt-4o-mini.
+  // panel. Verified against the OpenRouter models API: the slug exists, is free,
+  // and reports tool-calling support. If real-world free-tier tool-calling proves
+  // unreliable, swap to anthropic/claude-haiku-4.5 or openai/gpt-4o-mini (paid,
+  // both verified tool-capable).
   OPENROUTER_MODEL: 'google/gemma-4-31b-it:free',
   // Hybrid key handling: default false -> proxy route. When true, the user's own
   // key (OPENROUTER_API_KEY) is read from settings and sent direct to OPENROUTER_BASE.

--- a/eRequest-placer-AI/index.html
+++ b/eRequest-placer-AI/index.html
@@ -431,6 +431,18 @@
         <span class="bg-blue-800 px-1.5 py-0.5 rounded">Tip</span> run via a local server (<span class="mono">python3 -m http.server 8000</span>) instead of opening as <span class="mono">file://</span>.
       </p>
     </section>
+
+    <!-- AI Test Harness — hidden unless the page is opened with ?aitest=1.
+         Exercises the shared AI substrate (Ontoserver tools + agent loop)
+         independently of any feature UI. Kept in the codebase through phases 2-4. -->
+    <section id="ai-test-harness" class="bg-white p-4 rounded-2xl shadow hidden">
+      <h3 class="font-semibold mb-2">AI Test Harness <span class="text-xs font-normal text-gray-500">(?aitest=1)</span></h3>
+      <div class="flex flex-wrap gap-3 mb-3">
+        <button id="ai-test-search" class="px-4 py-2 bg-indigo-600 text-white rounded">Run search test</button>
+        <button id="ai-test-agent" class="px-4 py-2 bg-indigo-600 text-white rounded">Run agent test</button>
+      </div>
+      <pre id="ai-test-output" class="text-xs whitespace-pre-wrap bg-gray-50 border rounded p-3 max-h-96 overflow-auto">Ready. Tip: tick "Use my own OpenRouter key" in the Server panel's AI Settings before the agent test (the proxy route needs the worker deployed).</pre>
+    </section>
   </main>
 
   <!-- Floating toggles -->
@@ -448,6 +460,7 @@
         </div>
       </div>
       <div class="p-3">
+        <div id="ai-backend-banner" class="text-[11px] text-yellow-900 mb-2 font-medium bg-yellow-50 border border-yellow-200 rounded p-2">AI: initialising…</div>
         <div class="text-xs text-yellow-900 mb-1">Most recent URL:</div>
         <div id="last-expand-url" class="text-[11px] break-all bg-yellow-50 border border-yellow-200 rounded p-2"></div>
         <div class="text-xs text-yellow-900 mt-3 mb-1">History (most recent first):</div>
@@ -463,7 +476,7 @@
         <div class="font-semibold text-blue-900 text-sm">FHIR Server</div>
         <button id="server-close" class="text-xs px-2 py-1 rounded border border-blue-300 bg-white">Close</button>
       </div>
-      <div class="p-4 space-y-2">
+      <div id="server-panel-body" class="p-4 space-y-2 max-h-[85vh] overflow-y-auto">
         <label class="block">
           <span class="block text-sm font-medium">FHIR Server URL</span>
           <input id="fhir-base" class="border rounded w-full p-2 mono" value="https://server.callistemon.site/fhir" placeholder="https://your.fhir.server"/>

--- a/eRequest-placer-AI/modules/ai-agent.js
+++ b/eRequest-placer-AI/modules/ai-agent.js
@@ -1,0 +1,146 @@
+// modules/ai-agent.js — generic tool-using agent loop over the OpenRouter client.
+//
+// Feature-agnostic: callers supply the system/user prompts, the tool descriptors
+// (getTools()), and a toolImpl map { toolName: async (args) => result }. The loop
+// calls the model, dispatches any tool_calls, feeds results back, and repeats
+// until the model returns a plain answer (or maxIterations is hit). The final
+// content is parsed defensively into JSON.
+
+import { chatCompletion } from './openrouter-client.js';
+
+/**
+ * @param {object} opts
+ * @param {string} opts.systemPrompt
+ * @param {string} opts.userMessage
+ * @param {Array}  opts.tools          — OpenAI tool descriptors
+ * @param {Object} opts.toolImpl       — { name: async (args) => result }
+ * @param {string} [opts.model]
+ * @param {number} [opts.maxIterations=8]
+ * @param {AbortSignal} [opts.signal]
+ * @returns {Promise<{finalContent:string, parsed:any, transcript:Array, error?:string}>}
+ */
+export async function runAgent({
+  systemPrompt, userMessage, tools, toolImpl = {}, model, maxIterations = 8, signal,
+} = {}) {
+  const messages = [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: userMessage },
+  ];
+
+  for (let i = 0; i < maxIterations; i++) {
+    throwIfAborted(signal);
+
+    const resp = await chatCompletion({ model, messages, tools, signal });
+    const choice = resp && resp.choices && resp.choices[0];
+    const msg = choice && choice.message;
+    if (!msg) {
+      return { finalContent: '', parsed: null, transcript: messages, error: 'No message in model response' };
+    }
+
+    // Push the assistant turn verbatim (carries tool_calls / content).
+    messages.push(msg);
+
+    const toolCalls = Array.isArray(msg.tool_calls) ? msg.tool_calls : [];
+    if (toolCalls.length) {
+      for (const tc of toolCalls) {
+        throwIfAborted(signal);
+        const name = tc.function && tc.function.name;
+        let args = {};
+        try { args = JSON.parse((tc.function && tc.function.arguments) || '{}'); }
+        catch (_e) { args = {}; }
+
+        let result;
+        try {
+          const impl = toolImpl[name];
+          result = impl ? await impl(args) : { error: 'Unknown tool: ' + name };
+        } catch (e) {
+          if (e && e.name === 'AbortError') throw e;
+          result = { error: String((e && e.message) || e) };
+        }
+
+        messages.push({
+          role: 'tool',
+          tool_call_id: tc.id,
+          content: JSON.stringify(result),
+        });
+      }
+      continue; // let the model consume the tool results
+    }
+
+    // No tool calls -> this is the final answer.
+    const finalContent = msg.content || '';
+    return { finalContent, parsed: extractJson(finalContent), transcript: messages };
+  }
+
+  return {
+    finalContent: '', parsed: null, transcript: messages,
+    error: 'Agent did not produce a final answer within ' + maxIterations + ' iterations',
+  };
+}
+
+/**
+ * Defensive JSON extraction from a model's text output:
+ *   1. strict JSON.parse
+ *   2. ```json … ``` (or bare ```) fenced block
+ *   3. first balanced {…} or […] (string/escape aware)
+ * Returns the parsed value, or null if nothing parses.
+ */
+export function extractJson(text) {
+  if (typeof text !== 'string' || !text.trim()) return null;
+
+  // 1. strict
+  try { return JSON.parse(text); } catch (_e) { /* continue */ }
+
+  // 2. fenced code block
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence && fence[1]) {
+    try { return JSON.parse(fence[1].trim()); } catch (_e) { /* continue */ }
+  }
+
+  // 3. balanced bracket extraction — try whichever bracket type appears first
+  const candidates = [];
+  const obj = text.indexOf('{');
+  const arr = text.indexOf('[');
+  if (obj >= 0) candidates.push({ at: obj, open: '{', close: '}' });
+  if (arr >= 0) candidates.push({ at: arr, open: '[', close: ']' });
+  candidates.sort((a, b) => a.at - b.at);
+  for (const c of candidates) {
+    const sub = balancedSlice(text, c.at, c.open, c.close);
+    if (sub) {
+      try { return JSON.parse(sub); } catch (_e) { /* try next */ }
+    }
+  }
+  return null;
+}
+
+// Return the substring from `start` to the matching close bracket, honouring
+// string literals and escapes so brackets inside strings don't miscount.
+function balancedSlice(text, start, open, close) {
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (ch === '\\') esc = true;
+      else if (ch === '"') inStr = false;
+      continue;
+    }
+    if (ch === '"') { inStr = true; continue; }
+    if (ch === open) depth++;
+    else if (ch === close) {
+      depth--;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+function throwIfAborted(signal) {
+  if (signal && signal.aborted) {
+    const e = new Error('Aborted');
+    e.name = 'AbortError';
+    throw e;
+  }
+}

--- a/eRequest-placer-AI/modules/ontoserver-mcp.js
+++ b/eRequest-placer-AI/modules/ontoserver-mcp.js
@@ -1,0 +1,236 @@
+// modules/ontoserver-mcp.js — hand-rolled MCP Streamable-HTTP transport for the
+// Ontoserver MCP server (no SDK — keeps the static deploy dependency-free).
+//
+// JSON-RPC 2.0 over a single POST endpoint. The server may answer with either
+// `application/json` or a `text/event-stream` (SSE) body; both are handled. The
+// session id returned by `initialize` is captured from the Mcp-Session-Id
+// response header and echoed on every subsequent request.
+//
+// Tool contract (confirmed against the Ontoserver MCP product):
+//   search_concepts({ system, query, valueset, limit }) -> {"results":[{code,display}]}
+//   lookup_concept ({ system, code })                   -> {"display", ...}
+// The unified searchConcepts/lookupConcept below translate the issue's
+// { query, valueSetEcl, count } / { system, code } surface onto those tools and
+// normalise the result to { code, display, system }[].
+
+import { getAiSettings } from './settings-ai.js';
+import { setDebugUrl } from './utils.js';
+
+const JSONRPC = '2.0';
+const PROTOCOL_VERSION = '2025-03-26';
+const SCT = 'http://snomed.info/sct';
+
+export class McpTransportError extends Error {
+  constructor(message, { status, cause } = {}) {
+    super(message);
+    this.name = 'McpTransportError';
+    this.status = status ?? null;
+    this.cause = cause ?? null;
+  }
+}
+
+export class McpClient {
+  constructor(url) {
+    this.url = url;
+    this.sessionId = null;
+    this.nextId = 1;
+    this.initialized = false;
+  }
+
+  async initialize({ signal } = {}) {
+    const result = await this._request('initialize', {
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: 'callistemon-ai', version: '1.0' },
+    }, { signal });
+    // Per the spec, follow a successful initialize with the initialized
+    // notification. Failure here is non-fatal (best-effort).
+    await this._notify('notifications/initialized', {}, { signal });
+    this.initialized = true;
+    return result;
+  }
+
+  async listTools({ signal } = {}) {
+    const result = await this._request('tools/list', {}, { signal });
+    return (result && result.tools) || [];
+  }
+
+  async callTool(name, args, { signal } = {}) {
+    return this._request('tools/call', { name, arguments: args || {} }, { signal });
+  }
+
+  // ----- transport internals -----
+
+  _headers() {
+    const h = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+    };
+    if (this.sessionId) h['Mcp-Session-Id'] = this.sessionId;
+    return h;
+  }
+
+  async _request(method, params, { signal } = {}) {
+    const payload = { jsonrpc: JSONRPC, id: this.nextId++, method, params };
+    setDebugUrl(this.url + ' [mcp:' + method + ']');
+    let resp;
+    try {
+      resp = await fetch(this.url, {
+        method: 'POST', headers: this._headers(), body: JSON.stringify(payload), signal,
+      });
+    } catch (e) {
+      if (e && e.name === 'AbortError') throw e;
+      throw new McpTransportError('MCP transport error: ' + ((e && e.message) || e), { cause: e });
+    }
+
+    const sid = resp.headers.get('Mcp-Session-Id');
+    if (sid) this.sessionId = sid;
+
+    if (!resp.ok) {
+      throw new McpTransportError('MCP HTTP ' + resp.status, { status: resp.status });
+    }
+
+    const message = await this._parseBody(resp);
+    if (message && message.error) {
+      const m = message.error.message || JSON.stringify(message.error);
+      throw new McpTransportError('MCP JSON-RPC error: ' + m, { status: resp.status });
+    }
+    return message ? message.result : null;
+  }
+
+  async _notify(method, params, { signal } = {}) {
+    const payload = { jsonrpc: JSONRPC, method, params }; // no id -> notification
+    setDebugUrl(this.url + ' [mcp:' + method + ']');
+    try {
+      await fetch(this.url, {
+        method: 'POST', headers: this._headers(), body: JSON.stringify(payload), signal,
+      });
+    } catch (e) {
+      if (e && e.name === 'AbortError') throw e;
+      // notifications are fire-and-forget; a failure must not abort the session.
+      console.warn('MCP notify failed (' + method + ')', e);
+    }
+  }
+
+  async _parseBody(resp) {
+    const ct = (resp.headers.get('Content-Type') || '').toLowerCase();
+    const text = await resp.text();
+    if (ct.includes('text/event-stream')) {
+      const msg = parseLastSseJson(text);
+      if (msg) return msg;
+      throw new McpTransportError('MCP SSE body had no JSON data event');
+    }
+    try {
+      return JSON.parse(text);
+    } catch (e) {
+      // Some servers stream SSE without the matching content-type — try that too.
+      const msg = parseLastSseJson(text);
+      if (msg) return msg;
+      throw new McpTransportError('MCP response was not valid JSON', { cause: e });
+    }
+  }
+}
+
+// Parse an SSE payload and return the JSON object from the last decodable
+// `data:` block (ignores [DONE] sentinels and non-JSON keep-alives).
+function parseLastSseJson(text) {
+  const blocks = String(text).split(/\r?\n\r?\n/);
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const dataLines = blocks[i].split(/\r?\n/).filter((l) => l.startsWith('data:'));
+    if (!dataLines.length) continue;
+    const data = dataLines.map((l) => l.slice(5).replace(/^ /, '')).join('\n').trim();
+    if (!data || data === '[DONE]') continue;
+    try { return JSON.parse(data); } catch (_e) { /* keep scanning earlier blocks */ }
+  }
+  return null;
+}
+
+/**
+ * Reachability probe. Spins up a throwaway client and attempts `initialize`
+ * within `timeoutMs`. Never throws — returns a boolean.
+ */
+export async function probeMcp(url, timeoutMs = 2000) {
+  if (!url) return false;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const client = new McpClient(url);
+    await client.initialize({ signal: ctrl.signal });
+    return true;
+  } catch (_e) {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ----- shared, lazily-initialised client for the unified calls -----
+
+let sharedClient = null;
+
+async function getClient(signal) {
+  const url = getAiSettings().MCP_URL;
+  if (sharedClient && sharedClient.url === url && sharedClient.initialized) return sharedClient;
+  const client = new McpClient(url);
+  await client.initialize({ signal });
+  sharedClient = client;
+  return client;
+}
+
+// Extract the tool's textual JSON payload from a tools/call result.
+// MCP wraps tool output in { content: [{ type:'text', text }], structuredContent? }.
+function readToolJson(result) {
+  if (!result) return null;
+  if (result.structuredContent && typeof result.structuredContent === 'object') {
+    return result.structuredContent;
+  }
+  const content = Array.isArray(result.content) ? result.content : [];
+  for (const part of content) {
+    if (part && typeof part.text === 'string') {
+      try { return JSON.parse(part.text); } catch (_e) { /* try next part */ }
+    }
+  }
+  // Some servers return the payload directly as the result.
+  if (Array.isArray(result.results) || Array.isArray(result)) return result;
+  return null;
+}
+
+function normaliseConcepts(payload) {
+  if (!payload) return [];
+  // Ontoserver MCP shape: { results: [{ code, display }] }
+  let list = null;
+  if (Array.isArray(payload)) list = payload;
+  else if (Array.isArray(payload.results)) list = payload.results;
+  else if (payload.expansion && Array.isArray(payload.expansion.contains)) list = payload.expansion.contains;
+  if (!list) return [];
+  return list
+    .filter((c) => c && c.code)
+    .map((c) => ({ code: String(c.code), display: c.display || c.code, system: c.system || SCT }));
+}
+
+/** Unified concept search via MCP. Throws McpTransportError so the wrapper can fall back. */
+export async function searchConcepts({ query, valueSetEcl, count } = {}, { signal } = {}) {
+  const client = await getClient(signal);
+  const valueset = SCT + '?fhir_vs=ecl/' + encodeURIComponent(valueSetEcl || '');
+  const result = await client.callTool('search_concepts', {
+    system: 'snomed',
+    query: query || '',
+    valueset,
+    limit: count || 20,
+  }, { signal });
+  return normaliseConcepts(readToolJson(result));
+}
+
+/** Unified single-concept lookup via MCP. Throws McpTransportError on failure. */
+export async function lookupConcept({ system, code } = {}, { signal } = {}) {
+  const client = await getClient(signal);
+  const result = await client.callTool('lookup_concept', {
+    system: system && system !== SCT ? system : 'snomed',
+    code,
+  }, { signal });
+  const payload = readToolJson(result);
+  if (payload && (payload.display || payload.code)) {
+    return [{ code: String(payload.code || code), display: payload.display || code, system: system || SCT }];
+  }
+  return [];
+}

--- a/eRequest-placer-AI/modules/ontoserver-rest.js
+++ b/eRequest-placer-AI/modules/ontoserver-rest.js
@@ -1,0 +1,89 @@
+// modules/ontoserver-rest.js — REST fallback for the Ontoserver tool surface.
+//
+// Same surface as ontoserver-mcp.js (searchConcepts / lookupConcept, normalised
+// to { code, display, system }[]) but backed by plain FHIR terminology
+// operations on REST_TX_BASE:
+//   searchConcepts -> ValueSet/$expand  (SNOMED fhir_vs=ecl/… canonical url)
+//   lookupConcept  -> CodeSystem/$lookup
+//
+// The $expand request shape mirrors the CORS-proven path in
+// modules/terminology.js (expandFromOntoserver): the ECL is encoded once into
+// the canonical url, then URLSearchParams encodes the url param again — the
+// double layer is correct because the ECL lives in a query-string-within-a-url.
+
+import { getAiSettings } from './settings-ai.js';
+import { setDebugUrl } from './utils.js';
+
+const SCT = 'http://snomed.info/sct';
+
+function restBase() {
+  return (getAiSettings().REST_TX_BASE || '').replace(/\/+$/, '');
+}
+
+/** Surface OperationOutcome.diagnostics from an error body when present. */
+function diagnosticsFrom(json, fallback) {
+  try {
+    if (json && json.resourceType === 'OperationOutcome' && Array.isArray(json.issue)) {
+      const msg = json.issue.map((i) => i.diagnostics || (i.details && i.details.text) || i.code)
+        .filter(Boolean).join('; ');
+      if (msg) return msg;
+    }
+  } catch (_e) { /* fall through */ }
+  return fallback;
+}
+
+async function getJson(url, signal) {
+  setDebugUrl(url);
+  let r;
+  try {
+    r = await fetch(url, { headers: { Accept: 'application/fhir+json' }, signal });
+  } catch (e) {
+    if (e && e.name === 'AbortError') throw e;
+    throw new Error('Ontoserver REST transport error: ' + ((e && e.message) || e));
+  }
+  let json = null;
+  try { json = await r.json(); } catch (_e) { json = null; }
+  if (!r.ok) {
+    throw new Error(diagnosticsFrom(json, 'Ontoserver REST ' + r.status));
+  }
+  return json;
+}
+
+/** Unified concept search via FHIR ValueSet/$expand. */
+export async function searchConcepts({ query, valueSetEcl, count } = {}, { signal } = {}) {
+  const vsCanonical = SCT + '?fhir_vs=ecl/' + encodeURIComponent(valueSetEcl || '');
+  const u = new URL(restBase() + '/ValueSet/$expand');
+  u.searchParams.set('url', vsCanonical);
+  if (query && query.trim()) u.searchParams.set('filter', query);
+  u.searchParams.set('count', String(count || 20));
+  u.searchParams.set('includeDesignations', 'true');
+
+  const json = await getJson(u.toString(), signal);
+  const contains = (json && json.expansion && json.expansion.contains) || [];
+  return contains
+    .filter((c) => c && c.code)
+    .map((c) => ({ code: String(c.code), display: c.display || c.code, system: c.system || SCT }));
+}
+
+/** Unified single-concept lookup via FHIR CodeSystem/$lookup. */
+export async function lookupConcept({ system, code } = {}, { signal } = {}) {
+  if (!code) return [];
+  const u = new URL(restBase() + '/CodeSystem/$lookup');
+  u.searchParams.set('system', system || SCT);
+  u.searchParams.set('code', code);
+
+  const json = await getJson(u.toString(), signal);
+  const display = readParameter(json, 'display');
+  return display ? [{ code: String(code), display, system: system || SCT }] : [];
+}
+
+// Read a named value from a FHIR Parameters resource (e.g. $lookup output).
+function readParameter(json, name) {
+  try {
+    if (json && json.resourceType === 'Parameters' && Array.isArray(json.parameter)) {
+      const p = json.parameter.find((x) => x.name === name);
+      if (p) return p.valueString || p.valueCode || (p.value && (p.value.string || p.value.code)) || '';
+    }
+  } catch (_e) { /* ignore */ }
+  return '';
+}

--- a/eRequest-placer-AI/modules/ontoserver-tools.js
+++ b/eRequest-placer-AI/modules/ontoserver-tools.js
@@ -1,0 +1,97 @@
+// modules/ontoserver-tools.js — backend selection + unified Ontoserver surface.
+//
+// Probes MCP once at boot; on success uses MCP, otherwise REST. Per-call, if an
+// MCP request fails it sticky-falls-back to REST and stays there for the rest of
+// the session (the boot probe can pass while individual calls later CORS-fail).
+// getTools() returns the OpenAI tool descriptors the agent advertises to the
+// model; the names (search_concepts / lookup_concept) match spec §3.2.
+
+import { getAiSettings } from './settings-ai.js';
+import { probeMcp } from './ontoserver-mcp.js';
+import * as mcp from './ontoserver-mcp.js';
+import * as rest from './ontoserver-rest.js';
+
+let backend = 'unknown'; // 'mcp' | 'rest' | 'unknown'
+
+/** Probe MCP and set the active backend. Returns the resolved backend name. */
+export async function initOntoserverBackend() {
+  const url = getAiSettings().MCP_URL;
+  let ok = false;
+  try { ok = await probeMcp(url); } catch (_e) { ok = false; }
+  backend = ok ? 'mcp' : 'rest';
+  return backend;
+}
+
+/** 'mcp' | 'rest' | 'unknown' */
+export function getActiveBackendName() { return backend; }
+
+function stickyFallback(label, err) {
+  console.warn('Ontoserver MCP ' + label + ' failed; sticky fallback to REST', err);
+  backend = 'rest';
+}
+
+/** Unified concept search; delegates to the active backend with REST fallback. */
+export async function searchConcepts(args, opts) {
+  if (backend === 'mcp') {
+    try {
+      return await mcp.searchConcepts(args, opts);
+    } catch (e) {
+      if (e && e.name === 'AbortError') throw e;
+      stickyFallback('searchConcepts', e);
+    }
+  }
+  return rest.searchConcepts(args, opts);
+}
+
+/** Unified single-concept lookup; delegates to the active backend with REST fallback. */
+export async function lookupConcept(args, opts) {
+  if (backend === 'mcp') {
+    try {
+      return await mcp.lookupConcept(args, opts);
+    } catch (e) {
+      if (e && e.name === 'AbortError') throw e;
+      stickyFallback('lookupConcept', e);
+    }
+  }
+  return rest.lookupConcept(args, opts);
+}
+
+/** OpenAI-format tool descriptors advertised to the model. */
+export function getTools() {
+  return [
+    {
+      type: 'function',
+      function: {
+        name: 'search_concepts',
+        description: 'Search SNOMED CT for concepts matching a free-text term, constrained to an ECL value set. '
+          + 'Returns matching concepts as {code, display, system}. Always use this to confirm a concept exists '
+          + 'and is within scope before including it in your answer. Do not rely on concept IDs from memory.',
+        parameters: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Free-text term to search for, e.g. "type 2 diabetes".' },
+            valueSetEcl: { type: 'string', description: 'ECL expression constraining the searchable SNOMED hierarchy.' },
+            count: { type: 'integer', description: 'Maximum number of results to return (default 20).' },
+          },
+          required: ['query', 'valueSetEcl'],
+        },
+      },
+    },
+    {
+      type: 'function',
+      function: {
+        name: 'lookup_concept',
+        description: 'Look up a specific SNOMED CT concept by system and code to confirm its display term and that '
+          + 'it is valid and active. Use when you already have a candidate code and want to verify it.',
+        parameters: {
+          type: 'object',
+          properties: {
+            system: { type: 'string', description: 'Code system URI, e.g. http://snomed.info/sct.' },
+            code: { type: 'string', description: 'The concept code to look up.' },
+          },
+          required: ['system', 'code'],
+        },
+      },
+    },
+  ];
+}

--- a/eRequest-placer-AI/modules/ontoserver-tools.js
+++ b/eRequest-placer-AI/modules/ontoserver-tools.js
@@ -11,6 +11,9 @@ import { probeMcp } from './ontoserver-mcp.js';
 import * as mcp from './ontoserver-mcp.js';
 import * as rest from './ontoserver-rest.js';
 
+// 'unknown' until initOntoserverBackend() resolves the boot probe. Any concept
+// call made before then (e.g. a quick ?aitest=1 click) falls through to REST —
+// harmless, but it means MCP can be skipped for those early calls even when live.
 let backend = 'unknown'; // 'mcp' | 'rest' | 'unknown'
 
 /** Probe MCP and set the active backend. Returns the resolved backend name. */

--- a/eRequest-placer-AI/modules/openrouter-client.js
+++ b/eRequest-placer-AI/modules/openrouter-client.js
@@ -18,6 +18,7 @@ import { setDebugUrl } from './utils.js';
  *   'parse'        — 2xx body was not valid JSON
  *   'rate-limited' — 429 (after the single retry)
  *   'unauthorized' — 401/403
+ *   'not-configured'— default proxy route selected but the proxy isn't deployed yet
  */
 export class OpenRouterError extends Error {
   constructor(message, { status, body, kind } = {}) {
@@ -44,7 +45,7 @@ export async function chatCompletion({ model, messages, tools, signal } = {}) {
   const s = getAiSettings();
   const useOwnKey = !!s.USE_OWN_OPENROUTER_KEY;
 
-  const base = (useOwnKey ? s.OPENROUTER_BASE : s.PROXY_BASE_URL || '').replace(/\/+$/, '');
+  const base = ((useOwnKey ? s.OPENROUTER_BASE : s.PROXY_BASE_URL) || '').replace(/\/+$/, '');
   const url = base + '/chat/completions';
 
   const headers = {
@@ -62,6 +63,13 @@ export async function chatCompletion({ model, messages, tools, signal } = {}) {
         { kind: 'unauthorized' });
     }
     headers.Authorization = 'Bearer ' + key;
+  } else if (!s.PROXY_DEPLOYED) {
+    // Refuse the proxy route until issue #20 deploys the worker: PROXY_BASE_URL is
+    // an unclaimed workers.dev placeholder, so POSTing clinical free-text there is
+    // a data-egress risk. Steer the user to their own key for now.
+    throw new OpenRouterError(
+      'The managed AI proxy is not deployed yet. Tick "Use my own OpenRouter key" in AI Settings and add a key to use the demo.',
+      { kind: 'not-configured' });
   }
 
   const payload = {

--- a/eRequest-placer-AI/modules/openrouter-client.js
+++ b/eRequest-placer-AI/modules/openrouter-client.js
@@ -1,0 +1,156 @@
+// modules/openrouter-client.js — OpenRouter chat-completions client with hybrid
+// key handling (managed proxy by default, user-supplied key on override).
+//
+// Route is decided per-call from current settings, so flipping the "Use my own
+// OpenRouter key" toggle takes effect on the next call with no page reload:
+//   - default  -> POST ${PROXY_BASE_URL}/chat/completions, NO Authorization
+//                 (the Cloudflare Worker proxy injects the key upstream)
+//   - override -> POST ${OPENROUTER_BASE}/chat/completions with
+//                 Authorization: Bearer <userKey>
+
+import { getAiSettings } from './settings-ai.js';
+import { setDebugUrl } from './utils.js';
+
+/**
+ * Thrown for any non-success outcome. `kind` lets callers branch:
+ *   'transport'    — fetch itself failed (network/CORS)
+ *   'http'         — non-retryable HTTP error (4xx other than auth, or 5xx after retry)
+ *   'parse'        — 2xx body was not valid JSON
+ *   'rate-limited' — 429 (after the single retry)
+ *   'unauthorized' — 401/403
+ */
+export class OpenRouterError extends Error {
+  constructor(message, { status, body, kind } = {}) {
+    super(message);
+    this.name = 'OpenRouterError';
+    this.status = status ?? null;
+    this.body = body ?? null;
+    this.kind = kind || 'http';
+  }
+}
+
+const RETRY_DELAY_MS = 1000;
+
+/**
+ * Run one chat-completion turn.
+ * @param {object}   opts
+ * @param {string}  [opts.model]    — overrides the settings model
+ * @param {Array}    opts.messages  — OpenAI-format message array
+ * @param {Array}   [opts.tools]    — OpenAI tool descriptors (omitted if empty)
+ * @param {AbortSignal} [opts.signal]
+ * @returns {Promise<object>} the parsed OpenAI-format response
+ */
+export async function chatCompletion({ model, messages, tools, signal } = {}) {
+  const s = getAiSettings();
+  const useOwnKey = !!s.USE_OWN_OPENROUTER_KEY;
+
+  const base = (useOwnKey ? s.OPENROUTER_BASE : s.PROXY_BASE_URL || '').replace(/\/+$/, '');
+  const url = base + '/chat/completions';
+
+  const headers = {
+    'Content-Type': 'application/json',
+    // OpenRouter attribution headers (harmless on the proxy route too).
+    'HTTP-Referer': (typeof location !== 'undefined' && location.origin) || 'https://callistemon',
+    'X-Title': 'callistemon-ai',
+  };
+
+  if (useOwnKey) {
+    const key = (s.OPENROUTER_API_KEY || '').trim();
+    if (!key) {
+      throw new OpenRouterError(
+        'No OpenRouter API key set. Enter one in AI Settings, or untick "Use my own OpenRouter key" to use the managed proxy.',
+        { kind: 'unauthorized' });
+    }
+    headers.Authorization = 'Bearer ' + key;
+  }
+
+  const payload = {
+    model: model || s.OPENROUTER_MODEL,
+    messages,
+    temperature: 0.2,
+    stream: false,
+  };
+  if (Array.isArray(tools) && tools.length) {
+    payload.tools = tools;
+    payload.tool_choice = 'auto';
+  }
+  const body = JSON.stringify(payload);
+
+  // One retry on 429/5xx with a fixed backoff; no retry on other statuses.
+  let attempt = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    attempt++;
+    setDebugUrl(url + ' [openrouter:' + payload.model + (useOwnKey ? '' : ' via proxy') + ']');
+
+    let resp;
+    try {
+      resp = await fetch(url, { method: 'POST', headers, body, signal });
+    } catch (e) {
+      if (e && e.name === 'AbortError') throw e;
+      throw new OpenRouterError('Network error contacting ' + url, {
+        kind: 'transport', body: String((e && e.message) || e),
+      });
+    }
+
+    if (resp.ok) {
+      let json;
+      try { json = await resp.json(); }
+      catch (e) {
+        throw new OpenRouterError('OpenRouter returned a non-JSON success body', {
+          status: resp.status, kind: 'parse', body: String((e && e.message) || e),
+        });
+      }
+      return json;
+    }
+
+    const status = resp.status;
+    const errBody = await safeReadText(resp);
+
+    if ((status === 429 || status >= 500) && attempt < 2) {
+      await delay(RETRY_DELAY_MS, signal);
+      continue;
+    }
+    if (status === 401 || status === 403) {
+      throw new OpenRouterError(unauthorizedMessage(useOwnKey, status), {
+        status, kind: 'unauthorized', body: errBody,
+      });
+    }
+    if (status === 429) {
+      throw new OpenRouterError('OpenRouter rate limit reached (429). Try again shortly, or top up credits / switch model in AI Settings.', {
+        status, kind: 'rate-limited', body: errBody,
+      });
+    }
+    throw new OpenRouterError('OpenRouter request failed (' + status + ')', {
+      status, kind: 'http', body: errBody,
+    });
+  }
+}
+
+function unauthorizedMessage(useOwnKey, status) {
+  if (useOwnKey) {
+    return 'OpenRouter rejected your API key (' + status + '). Check the key in AI Settings.';
+  }
+  return 'The AI proxy rejected the request (' + status + '). It may be down or rate-limited. ' +
+    'You can tick "Use my own OpenRouter key" in AI Settings to call OpenRouter directly.';
+}
+
+async function safeReadText(resp) {
+  try { return await resp.text(); } catch (_e) { return ''; }
+}
+
+function delay(ms, signal) {
+  return new Promise((resolve, reject) => {
+    if (signal && signal.aborted) { reject(makeAbortError()); return; }
+    const t = setTimeout(resolve, ms);
+    if (signal) {
+      signal.addEventListener('abort', () => { clearTimeout(t); reject(makeAbortError()); }, { once: true });
+    }
+  });
+}
+
+function makeAbortError() {
+  const e = new Error('Aborted');
+  e.name = 'AbortError';
+  return e;
+}

--- a/eRequest-placer-AI/modules/settings-ai.js
+++ b/eRequest-placer-AI/modules/settings-ai.js
@@ -1,0 +1,211 @@
+// modules/settings-ai.js — localStorage-backed AI settings store + settings UI extension.
+//
+// SECURITY / KEY-EXPOSURE NOTE
+// ----------------------------
+// Two routes, selected by the USE_OWN_OPENROUTER_KEY toggle:
+//
+//   Default mode (USE_OWN_OPENROUTER_KEY = false):
+//     The browser holds NO OpenRouter API key. Chat-completion calls go to the
+//     managed Cloudflare Worker proxy, which injects the key server-side. Nothing
+//     sensitive is stored client-side.
+//
+//   Override mode (USE_OWN_OPENROUTER_KEY = true):
+//     The user's own OpenRouter API key is stored in localStorage under
+//     AI_SETTINGS_KEY and sent directly to OpenRouter as `Authorization: Bearer`.
+//     This carries the SAME risk posture as the FHIR auth passwords this app
+//     already stores (see modules/server.js): readable by any script on this
+//     origin and by anyone with access to the browser. Acceptable for a
+//     demo/reference app; production adopters should be warned (spec §9, §9.1).
+//
+// All settings are a single JSON blob keyed by AI_SETTINGS_KEY, layered over
+// AI_DEFAULTS so newly-added defaults appear automatically for existing users.
+
+import { AI_DEFAULTS, AI_SETTINGS_KEY } from '../config.js';
+
+// Models offered in the settings dropdown. The stored model is added on top if
+// it isn't already listed, so an operator-set custom model is never lost.
+const MODEL_OPTIONS = [
+  'google/gemma-4-31b-it:free',
+  'anthropic/claude-haiku-4-5',
+  'anthropic/claude-sonnet-4-5',
+  'openai/gpt-4o-mini',
+];
+
+// ----- Store -----
+
+/** Read the merged settings object (defaults overlaid with stored overrides). */
+export function getAiSettings() {
+  let stored = {};
+  try {
+    const raw = localStorage.getItem(AI_SETTINGS_KEY);
+    if (raw) stored = JSON.parse(raw) || {};
+  } catch (_e) { stored = {}; }
+  return { ...AI_DEFAULTS, ...stored };
+}
+
+/** Persist a single setting, merged into the existing blob. */
+export function setAiSetting(key, value) {
+  let stored = {};
+  try {
+    const raw = localStorage.getItem(AI_SETTINGS_KEY);
+    if (raw) stored = JSON.parse(raw) || {};
+  } catch (_e) { stored = {}; }
+  stored[key] = value;
+  try { localStorage.setItem(AI_SETTINGS_KEY, JSON.stringify(stored)); }
+  catch (_e) { /* storage blocked — settings stay in-memory for this load only */ }
+}
+
+/** Clear all stored overrides, reverting to AI_DEFAULTS. */
+export function resetAiSettings() {
+  try { localStorage.removeItem(AI_SETTINGS_KEY); }
+  catch (_e) { /* storage blocked */ }
+}
+
+/** Master AI toggle. */
+export function isAiEnabled() {
+  return !!getAiSettings().AI_FEATURES_ENABLED;
+}
+
+/** Decision support is gated by both its own toggle and the master toggle. */
+export function isDecisionSupportEnabled() {
+  const s = getAiSettings();
+  return !!s.AI_FEATURES_ENABLED && !!s.DECISION_SUPPORT_ENABLED;
+}
+
+// ----- UI extension -----
+
+let panelInitialised = false;
+
+/**
+ * Extend the existing #server-panel popout with an "AI Settings" <details> block.
+ * Idempotent. Does NOT introduce a new floating button (spec / issue requirement).
+ */
+export function initAiSettingsPanel() {
+  if (panelInitialised) return;
+  const host = document.getElementById('server-panel-body');
+  if (!host) return;
+
+  const s = getAiSettings();
+  const details = document.createElement('details');
+  details.className = 'ai-settings mt-2';
+  details.innerHTML = buildPanelHtml(s);
+  host.appendChild(details);
+
+  wirePanel(details, s);
+  panelInitialised = true;
+}
+
+function modelOptionsHtml(current) {
+  const opts = MODEL_OPTIONS.slice();
+  if (current && !opts.includes(current)) opts.unshift(current);
+  return opts.map((m) =>
+    `<option value="${escapeAttr(m)}"${m === current ? ' selected' : ''}>${escapeHtml(m)}</option>`
+  ).join('');
+}
+
+function buildPanelHtml(s) {
+  const ta = 'border rounded w-full p-2 mono text-xs';
+  return `
+    <summary class="text-sm font-semibold text-blue-900">AI Settings</summary>
+    <div class="mt-2 space-y-3 text-sm">
+      <label class="flex items-center gap-2">
+        <input type="checkbox" id="ai-enabled" class="accent-blue-600"${s.AI_FEATURES_ENABLED ? ' checked' : ''}>
+        <span class="font-medium">Enable AI features</span>
+      </label>
+      <label class="flex items-center gap-2">
+        <input type="checkbox" id="ai-decision-support-enabled" class="accent-blue-600"${s.DECISION_SUPPORT_ENABLED ? ' checked' : ''}>
+        <span class="font-medium">Enable decision support</span>
+      </label>
+
+      <label class="block">
+        <span class="block text-xs font-medium text-gray-600">Model</span>
+        <select id="ai-model" class="border rounded w-full p-2 text-sm">${modelOptionsHtml(s.OPENROUTER_MODEL)}</select>
+      </label>
+
+      <label class="flex items-center gap-2">
+        <input type="checkbox" id="ai-use-own-key" class="accent-blue-600"${s.USE_OWN_OPENROUTER_KEY ? ' checked' : ''}>
+        <span class="font-medium">Use my own OpenRouter key</span>
+      </label>
+      <label class="block ${s.USE_OWN_OPENROUTER_KEY ? '' : 'hidden'}" id="ai-key-field">
+        <span class="block text-xs font-medium text-gray-600">OpenRouter API key</span>
+        <input type="password" id="ai-api-key" class="border rounded w-full p-2 mono text-xs" autocomplete="off"
+               placeholder="sk-or-..." value="${escapeAttr(s.OPENROUTER_API_KEY || '')}">
+        <span class="block text-[11px] text-gray-500 mt-1">Stored in localStorage on this device only — same risk posture as the FHIR auth password.</span>
+      </label>
+
+      <label class="block">
+        <span class="block text-xs font-medium text-gray-600">Reason coding ECL (Feature A)</span>
+        <textarea id="ai-reason-ecl" rows="2" class="${ta}">${escapeHtml(s.REASON_ECL || '')}</textarea>
+      </label>
+      <label class="block">
+        <span class="block text-xs font-medium text-gray-600">Test selection ECL (Feature B)</span>
+        <textarea id="ai-test-ecl" rows="2" class="${ta}">${escapeHtml(s.TEST_ECL || '')}</textarea>
+      </label>
+
+      <label class="block">
+        <span class="block text-xs font-medium text-gray-600">Pre-prompt supplements</span>
+        <textarea id="ai-supplements" rows="2" class="${ta}">${escapeHtml(s.PRE_PROMPT_SUPPLEMENTS || '')}</textarea>
+      </label>
+      <label class="block">
+        <span class="block text-xs font-medium text-gray-600">Guidelines summary (decision support)</span>
+        <textarea id="ai-guidelines" rows="3" class="${ta}">${escapeHtml(s.GUIDELINES_SUMMARY || '')}</textarea>
+      </label>
+
+      <div class="flex justify-end">
+        <button type="button" id="ai-reset" class="text-xs px-2 py-1 rounded border bg-white">Reset AI settings</button>
+      </div>
+    </div>`;
+}
+
+function wirePanel(root, s) {
+  const $ = (sel) => root.querySelector(sel);
+
+  const enabled = $('#ai-enabled');
+  const decision = $('#ai-decision-support-enabled');
+  const model = $('#ai-model');
+  const useOwnKey = $('#ai-use-own-key');
+  const keyField = $('#ai-key-field');
+  const apiKey = $('#ai-api-key');
+  const reasonEcl = $('#ai-reason-ecl');
+  const testEcl = $('#ai-test-ecl');
+  const supplements = $('#ai-supplements');
+  const guidelines = $('#ai-guidelines');
+  const reset = $('#ai-reset');
+
+  // Master + decision-support toggles fire ai-enabled-changed so app.js can
+  // show/hide the .ai-feature-controls elements without a reload.
+  function fireEnabledChanged() {
+    document.dispatchEvent(new CustomEvent('ai-enabled-changed', {
+      detail: { aiEnabled: isAiEnabled(), decisionSupportEnabled: isDecisionSupportEnabled() },
+    }));
+  }
+
+  enabled.addEventListener('change', () => { setAiSetting('AI_FEATURES_ENABLED', enabled.checked); fireEnabledChanged(); });
+  decision.addEventListener('change', () => { setAiSetting('DECISION_SUPPORT_ENABLED', decision.checked); fireEnabledChanged(); });
+  model.addEventListener('change', () => setAiSetting('OPENROUTER_MODEL', model.value));
+  useOwnKey.addEventListener('change', () => {
+    setAiSetting('USE_OWN_OPENROUTER_KEY', useOwnKey.checked);
+    keyField.classList.toggle('hidden', !useOwnKey.checked);
+  });
+  apiKey.addEventListener('input', () => setAiSetting('OPENROUTER_API_KEY', apiKey.value.trim()));
+  reasonEcl.addEventListener('input', () => setAiSetting('REASON_ECL', reasonEcl.value));
+  testEcl.addEventListener('input', () => setAiSetting('TEST_ECL', testEcl.value));
+  supplements.addEventListener('input', () => setAiSetting('PRE_PROMPT_SUPPLEMENTS', supplements.value));
+  guidelines.addEventListener('input', () => setAiSetting('GUIDELINES_SUMMARY', guidelines.value));
+  reset.addEventListener('click', () => {
+    resetAiSettings();
+    panelInitialised = false;
+    root.remove();
+    initAiSettingsPanel();
+    fireEnabledChanged();
+  });
+}
+
+// ----- tiny HTML escapers (settings values are operator-controlled, but ECL /
+// keys can contain <, >, &, " which must not break the injected markup) -----
+function escapeHtml(v) {
+  return String(v).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+function escapeAttr(v) {
+  return escapeHtml(v).replace(/"/g, '&quot;');
+}

--- a/eRequest-placer-AI/modules/settings-ai.js
+++ b/eRequest-placer-AI/modules/settings-ai.js
@@ -26,8 +26,8 @@ import { AI_DEFAULTS, AI_SETTINGS_KEY } from '../config.js';
 // it isn't already listed, so an operator-set custom model is never lost.
 const MODEL_OPTIONS = [
   'google/gemma-4-31b-it:free',
-  'anthropic/claude-haiku-4-5',
-  'anthropic/claude-sonnet-4-5',
+  'anthropic/claude-haiku-4.5',
+  'anthropic/claude-sonnet-4.5',
   'openai/gpt-4o-mini',
 ];
 
@@ -172,8 +172,9 @@ function wirePanel(root, s) {
   const guidelines = $('#ai-guidelines');
   const reset = $('#ai-reset');
 
-  // Master + decision-support toggles fire ai-enabled-changed so app.js can
-  // show/hide the .ai-feature-controls elements without a reload.
+  // Master + decision-support toggles fire ai-enabled-changed. The feature phases
+  // (Phase 2+, PLAN.md §147) add the listener that shows/hides the
+  // .ai-feature-controls elements without a reload; no such listener exists yet.
   function fireEnabledChanged() {
     document.dispatchEvent(new CustomEvent('ai-enabled-changed', {
       detail: { aiEnabled: isAiEnabled(), decisionSupportEnabled: isDecisionSupportEnabled() },

--- a/index.html
+++ b/index.html
@@ -39,6 +39,12 @@
             <p><b>Start here, and create a eRequest!</b></p>
           </a>
 
+          <a href="/callistemon/eRequest-placer-AI/" class="block bg-white rounded-2xl shadow hover:shadow-lg transition p-6">
+            <h3 class="text-xl font-bold text-red-700">eRequest Placer — AI variant</h3>
+            <p class="mt-2 text-gray-600">An AI-enhanced sister of the eRequest Placer. Once complete, this variant will derive SNOMED CT reason codes from free-text clinical notes, derive procedure codes from natural-language test descriptions, and run pre-send clinical decision support — backed by Openrouter and Ontoserver MCP.</p>
+            <p><b>Currently a Phase 0 scaffold — functionally identical to the original eRequest Placer. AI features arrive in later phases (see PLAN.md).</b></p>
+          </a>
+
           <a href="/callistemon/eRequest-dashboard/" class="block bg-white rounded-2xl shadow hover:shadow-lg transition p-6">
             <h3 class="text-xl font-bold text-red-700">eRequest Dashboard</h3>
             <p class="mt-2 text-gray-600">An interactive dashboard for exploring service requests with advanced filters powered by SNOMED CT and FHIR terminology services. The dashboard updates in real time as new requests arrive and existing ones change.</p>


### PR DESCRIPTION
Closes #14.

Builds the shared AI substrate that Features A, B and C will reuse. **No feature UI yet** — verified with a manual test harness behind `?aitest=1`.

## What's here

**config.js** — `AI_DEFAULTS` (proxy/OpenRouter URLs, model, ECLs, supplements, toggles) + `AI_SETTINGS_KEY`.

**Six new modules** under `eRequest-placer-AI/modules/`:
- `settings-ai.js` — localStorage store + an "AI Settings" `<details>` injected into the existing `#server-panel` (no new floating button); fires `ai-enabled-changed`. Security/key-exposure note in the file header.
- `openrouter-client.js` — `chatCompletion(...)` with **per-call** hybrid routing (managed proxy by default, user key on override), 429/5xx retry, `OpenRouterError{status,body,kind}`.
- `ontoserver-mcp.js` — hand-rolled MCP Streamable-HTTP client (JSON + SSE, session capture), `McpClient` / `probeMcp` / unified search+lookup.
- `ontoserver-rest.js` — FHIR `$expand` / `$lookup` fallback reusing the proven request shape; surfaces `OperationOutcome.diagnostics`.
- `ontoserver-tools.js` — boot probe → backend selection, sticky REST fallback, `getTools()` descriptors.
- `ai-agent.js` — `runAgent(...)` tool-loop + defensive JSON extractor (strict → fence → balanced).

**Wiring** — `index.html` gets the `?aitest=1` harness + a debug-panel AI banner; `app.js` calls `initAiSettingsPanel()`, probes the backend at boot, updates the banner, and wires the harness.

Also includes the pre-existing Phase 1 planning commits (PLAN.md hybrid-key + model rationale, landing-page card) that were on `phase-0-scaffold` but not part of the #19 merge.

## Verification

- `node --check` on all modules; export graph + pure-logic (`extractJson`, `getTools`) smoke-tested.
- **Live backends**: MCP transport against `https://ontoserver.app/mcp` initialized, called tools, parsed JSON/SSE, normalized; REST `$expand` returned correct concepts; `lookupConcept` works on both.
- **Hybrid-key contract**: default → proxy URL, no `Authorization`; override → OpenRouter + `Bearer`; `tools`/`tool_choice` only when tools passed; toggle takes effect per-call; empty override key throws `unauthorized` without fetching.
- **Browser boot** (Edge headless): clean load, AI Settings panel injects with correct defaults (key field hidden until ticked), harness reveals under `?aitest=1`, banner reads `backend = mcp · model = …`, MCP POSTs appear in the recent-calls panel.

## Not yet verifiable here
- **Default proxy mode** end-to-end waits on the Cloudflare Worker proxy issue. Dev/verification uses the "Use my own OpenRouter key" override path.
- The **agent test** needs a personal OpenRouter key pasted into AI Settings.

## Possible follow-up
The MCP **client transport** is hand-rolled (per the issue, to keep the static deploy SDK-free). Worth revisiting after Phases 2–4 whether the official MCP SDK and/or the richer Ontoserver MCP tool surface (`validate_concept`, `expand_valueset`, `find_mappings`, `check_subsumption`) add enough value to justify the dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)