### PR TITLE
Phase 2 — Feature A: AI-assisted reason coding

### DIFF
--- a/eRequest-placer-AI/app.js
+++ b/eRequest-placer-AI/app.js
@@ -13,7 +13,7 @@ import {
   updatePtToggleVisuals,
 } from './modules/patient.js';
 import {
-  renderReasonTags, wireNotesAutocomplete,
+  renderReasonTags, wireNotesAutocomplete, addReasonTag,
 } from './modules/reason-tags.js';
 import {
   setupSearch, setupCustomAdder, renderFavsForUser, renderSelectedTests, initBodySiteModal,
@@ -39,6 +39,10 @@ import {
   searchConcepts, lookupConcept, getTools,
 } from './modules/ontoserver-tools.js';
 import { runAgent } from './modules/ai-agent.js';
+import { suggestReasonCodes } from './modules/ai-reason-coding.js';
+import {
+  renderSuggestionReviewList, setLoadingState, renderEmptyState, renderErrorState,
+} from './modules/ai-ui.js';
 
 // JSON viewer instance — owned by this module (boot sets it). Domain modules
 // like bundle-builder.js are no longer aware of it; the caller of buildBundle()
@@ -109,6 +113,54 @@ function initAiTestHarness() {
       agentBtn.classList.remove('btn-disabled');
     }
   });
+}
+
+// Feature A wiring: enable the Suggest-codes button when notes are present, run
+// the agent on click, and route the review list's accept actions through
+// addReasonTag (tagging them source:'ai' so they render as distinct indigo chips).
+function initReasonCoding() {
+  const notes = document.getElementById('clinical-notes');
+  const btn = document.getElementById('ai-suggest-codes');
+  const status = document.getElementById('ai-codes-status');
+  const review = document.getElementById('ai-codes-review');
+  if (!notes || !btn || !review) return;
+
+  const updateBtnState = () => { btn.disabled = !notes.value.trim(); };
+  notes.addEventListener('input', updateBtnState);
+  updateBtnState();
+
+  async function run() {
+    setLoadingState(btn, true, 'Deriving codes…');
+    if (status) status.textContent = 'Deriving codes…';
+    review.classList.add('hidden');
+    review.replaceChildren();
+    let outcome = '';
+    try {
+      const { codes, error } = await suggestReasonCodes();
+      if (error) {
+        renderErrorState(review, error, run);
+        outcome = 'Could not derive codes';
+      } else if (!codes.length) {
+        renderEmptyState(review, 'No codes could be confidently derived. Please add codes manually.');
+        outcome = 'No codes derived';
+      } else {
+        renderSuggestionReviewList({
+          container: review,
+          items: codes,
+          kind: 'reason',
+          onAccept: (item) => addReasonTag({ ...item, source: 'ai' }),
+          onAcceptAll: (items) => items.forEach((item) => addReasonTag({ ...item, source: 'ai' })),
+        });
+        outcome = codes.length + ' suggestion' + (codes.length === 1 ? '' : 's') + ' to review';
+      }
+    } finally {
+      setLoadingState(btn, false);
+      if (status) status.textContent = outcome;
+      updateBtnState(); // re-apply content-based disabled state after restoring the button
+    }
+  }
+
+  btn.addEventListener('click', run);
 }
 
 function boot() {
@@ -297,6 +349,9 @@ function boot() {
 
   // ----- Notes autocomplete -----
   wireNotesAutocomplete();
+
+  // ----- Feature A: AI reason coding -----
+  initReasonCoding();
 
   // ----- Pregnancy status -----
   populatePregnancyStatus();

--- a/eRequest-placer-AI/app.js
+++ b/eRequest-placer-AI/app.js
@@ -125,24 +125,33 @@ function initReasonCoding() {
   const review = document.getElementById('ai-codes-review');
   if (!notes || !btn || !review) return;
 
-  const updateBtnState = () => { btn.disabled = !notes.value.trim(); };
+  let isRunning = false;
+  const setStatus = (text) => { if (status) status.textContent = text; };
+  // Reflect the remaining review count; clears at 0 so the hint never lingers
+  // after accept-all / reject-all (or the last individual accept/reject).
+  const reviewCount = (n) => setStatus(n > 0 ? (n + ' suggestion' + (n === 1 ? '' : 's') + ' to review') : '');
+  // Disabled while a run is in flight (prevents a concurrent submission even if
+  // the user edits the notes mid-run) or when there is nothing to send.
+  const updateBtnState = () => { btn.disabled = isRunning || !notes.value.trim(); };
   notes.addEventListener('input', updateBtnState);
   updateBtnState();
 
   async function run() {
+    if (isRunning) return;
+    isRunning = true;
     setLoadingState(btn, true, 'Deriving codes…');
-    if (status) status.textContent = 'Deriving codes…';
+    updateBtnState();
+    setStatus('Deriving codes…');
     review.classList.add('hidden');
     review.replaceChildren();
-    let outcome = '';
     try {
       const { codes, error } = await suggestReasonCodes();
       if (error) {
         renderErrorState(review, error, run);
-        outcome = 'Could not derive codes';
+        setStatus('Could not derive codes');
       } else if (!codes.length) {
         renderEmptyState(review, 'No codes could be confidently derived. Please add codes manually.');
-        outcome = 'No codes derived';
+        setStatus('No codes derived');
       } else {
         renderSuggestionReviewList({
           container: review,
@@ -150,13 +159,13 @@ function initReasonCoding() {
           kind: 'reason',
           onAccept: (item) => addReasonTag({ ...item, source: 'ai' }),
           onAcceptAll: (items) => items.forEach((item) => addReasonTag({ ...item, source: 'ai' })),
+          onCountChange: reviewCount, // keeps #ai-codes-status fresh; clears at 0
         });
-        outcome = codes.length + ' suggestion' + (codes.length === 1 ? '' : 's') + ' to review';
       }
     } finally {
+      isRunning = false;
       setLoadingState(btn, false);
-      if (status) status.textContent = outcome;
-      updateBtnState(); // re-apply content-based disabled state after restoring the button
+      updateBtnState();
     }
   }
 

--- a/eRequest-placer-AI/index.html
+++ b/eRequest-placer-AI/index.html
@@ -315,6 +315,13 @@
         <label class="block font-medium mb-1">Clinical Notes</label>
         <textarea id="clinical-notes" class="w-full border rounded p-2 h-50" placeholder="Optional clinical context for the request"></textarea>
 
+        <!-- Feature A: AI reason coding. .ai-feature-controls is the master-toggle hook (Phase 5). -->
+        <div class="mt-2 flex items-center gap-2 ai-feature-controls">
+          <button id="ai-suggest-codes" class="px-3 py-1.5 text-sm bg-indigo-600 text-white rounded disabled:opacity-50" disabled>✨ Suggest codes</button>
+          <span id="ai-codes-status" class="text-xs text-gray-500" aria-live="polite"></span>
+        </div>
+        <div id="ai-codes-review" class="mt-3 hidden"></div>
+
         <div id="notes-suggestions" class="mt-2 hidden">
           <div class="text-xs text-gray-500 mb-1">Autocomplete suggestions</div>
           <div id="notes-suggestion-list" class="flex flex-wrap gap-2"></div>

--- a/eRequest-placer-AI/modules/ai-reason-coding.js
+++ b/eRequest-placer-AI/modules/ai-reason-coding.js
@@ -1,0 +1,112 @@
+// modules/ai-reason-coding.js — Feature A: derive SNOMED CT reason codes from the
+// free-text Clinical Notes via the shared agent loop, scoped to REASON_ECL.
+//
+// Accuracy over completeness (spec §3.4, §10.3): the search tool is hard-coerced
+// to REASON_ECL regardless of what the model asks for, and every returned code is
+// re-confirmed in-scope against Ontoserver before being surfaced — so a
+// hallucinated code can't slip through even if the model invented it post-search.
+
+import { getAiSettings } from './settings-ai.js';
+import { runAgent } from './ai-agent.js';
+import { getTools, searchConcepts, lookupConcept } from './ontoserver-tools.js';
+
+const SCT = 'http://snomed.info/sct';
+
+// Spec §4.5, verbatim. {reason_ecl} is substituted at call time.
+const SYSTEM_PROMPT = [
+  'You are a clinical coding assistant. Your task is to derive a minimal, accurate set of SNOMED CT codes representing the clinical meaning of a clinician\'s free-text notes.',
+  '',
+  'Prioritise accuracy over completeness. Return only codes you are confident are correct. Do not speculate. Do not use concept IDs from memory.',
+  '',
+  'You have access to an Ontoserver MCP tool. Use `search_concepts` with the ECL expression `{reason_ecl}` to find and confirm every concept before including it. Only include a code if Ontoserver confirms it is valid, active, and within the ECL scope. If no match is found, omit the concept.',
+  '',
+  'Return a JSON array only, no prose or markdown formatting.',
+].join('\n');
+
+/** Approximate age in whole years from a yyyy-mm-dd date string; null if absent/invalid. */
+export function ageFromDob(dobStr) {
+  if (!dobStr) return null;
+  const dob = new Date(dobStr);
+  if (isNaN(dob.getTime())) return null;
+  const now = new Date();
+  let age = now.getFullYear() - dob.getFullYear();
+  const m = now.getMonth() - dob.getMonth();
+  if (m < 0 || (m === 0 && now.getDate() < dob.getDate())) age--;
+  return (age >= 0 && age < 200) ? age : null;
+}
+
+function gatherContext() {
+  const notes = (document.getElementById('clinical-notes').value || '').trim();
+  const age = ageFromDob(document.getElementById('patient-dob').value);
+  const sex = document.getElementById('patient-gender').value || 'unknown';
+  const pregEl = document.getElementById('pregnancy-status');
+  // Include pregnancy only if a status is actually selected.
+  const pregnancy = (pregEl && pregEl.value) ? (pregEl.selectedOptions[0] && pregEl.selectedOptions[0].textContent.trim()) : null;
+  return { clinical_notes: notes, age, sex, pregnancy };
+}
+
+// Defence in depth: confirm the candidate's code is returned by an in-scope search
+// for its display term. Drops hallucinated codes. Conservative on error (drops).
+async function confirmInScope(candidate, reasonEcl) {
+  try {
+    const results = await searchConcepts({ query: candidate.display, valueSetEcl: reasonEcl, count: 30 });
+    return results.some((r) => r.code === candidate.code);
+  } catch (_e) {
+    return false;
+  }
+}
+
+/**
+ * Derive validated reason codes from the current Clinical Notes + patient context.
+ * @returns {Promise<{codes: Array<{code,display,system}>, error: string|null}>}
+ */
+export async function suggestReasonCodes() {
+  try {
+    const s = getAiSettings();
+    const reasonEcl = (s.REASON_ECL || '').trim();
+    if (!reasonEcl) {
+      return { codes: [], error: 'Reason coding ECL is not set — add one in AI Settings.' };
+    }
+
+    const ctx = gatherContext();
+    if (!ctx.clinical_notes) {
+      return { codes: [], error: 'Enter clinical notes before suggesting codes.' };
+    }
+
+    const systemPrompt = SYSTEM_PROMPT.replace('{reason_ecl}', reasonEcl);
+    const userMessage = JSON.stringify(ctx);
+
+    // search_concepts is hard-coerced to REASON_ECL no matter what the model passes.
+    const toolImpl = {
+      search_concepts: (args) => searchConcepts({ ...args, valueSetEcl: reasonEcl }),
+      lookup_concept: (args) => lookupConcept(args),
+    };
+
+    const { parsed, error } = await runAgent({
+      systemPrompt,
+      userMessage,
+      tools: getTools(),
+      toolImpl,
+      model: s.OPENROUTER_MODEL,
+    });
+
+    if (error) return { codes: [], error };
+    if (!Array.isArray(parsed)) return { codes: [], error: null }; // empty/non-array → nothing usable
+
+    // Validate, normalise, dedupe by code.
+    const seen = new Set();
+    const unique = parsed
+      .filter((e) => e && e.code && e.display)
+      .map((e) => ({ code: String(e.code), display: String(e.display), system: e.system || SCT }))
+      .filter((c) => (seen.has(c.code) ? false : (seen.add(c.code), true)));
+
+    // Confirm each in-scope (parallel); keep only confirmed.
+    const oks = await Promise.all(unique.map((c) => confirmInScope(c, reasonEcl)));
+    const codes = unique.filter((_, i) => oks[i]);
+
+    return { codes, error: null };
+  } catch (e) {
+    if (e && e.name === 'AbortError') return { codes: [], error: 'Cancelled.' };
+    return { codes: [], error: String((e && e.message) || e) };
+  }
+}

--- a/eRequest-placer-AI/modules/ai-ui.js
+++ b/eRequest-placer-AI/modules/ai-ui.js
@@ -1,0 +1,179 @@
+// modules/ai-ui.js — shared UI helpers for the AI features (Feature A reason
+// coding now; reused by Feature B test selection and Feature C decision support).
+//
+// Pure DOM, no module imports. All text rendered via textContent — values may be
+// AI-sourced, so nothing here uses innerHTML.
+
+const KIND_STYLES = {
+  // AI suggestion chips use indigo + ✨ so they are visibly distinct from the
+  // emerald manual reason chips (see reason-tags.js).
+  reason:  { chip: 'border-indigo-200 bg-indigo-50 text-indigo-800', spark: true, heading: 'AI-suggested reason codes' },
+  test:    { chip: 'border-indigo-200 bg-indigo-50 text-indigo-800', spark: true, heading: 'AI-suggested tests' },
+  finding: { chip: 'border-amber-200 bg-amber-50 text-amber-800',   spark: false, heading: 'Findings' },
+};
+
+/**
+ * Render an accept/reject review list of AI suggestions into `container`.
+ * Owns a working copy of `items`; accept/reject splice it and re-render, so the
+ * caller's callbacks only handle side effects. Hides + empties the container
+ * once nothing remains.
+ *
+ * @param {object} o
+ * @param {HTMLElement} o.container
+ * @param {Array<{system?:string,code:string,display:string}>} o.items
+ * @param {(item:object)=>void} [o.onAccept]
+ * @param {(item:object)=>void} [o.onReject]
+ * @param {(remaining:object[])=>void} [o.onAcceptAll]
+ * @param {()=>void} [o.onRejectAll]
+ * @param {'reason'|'test'|'finding'} [o.kind]
+ */
+export function renderSuggestionReviewList({
+  container, items, onAccept, onReject, onAcceptAll, onRejectAll, kind = 'reason',
+}) {
+  if (!container) return;
+  const style = KIND_STYLES[kind] || KIND_STYLES.reason;
+  const working = Array.isArray(items) ? items.slice() : [];
+
+  const remove = (item) => { const i = working.indexOf(item); if (i > -1) working.splice(i, 1); };
+
+  function render() {
+    container.replaceChildren();
+    if (!working.length) { container.classList.add('hidden'); return; }
+    container.classList.remove('hidden');
+
+    // ----- header: count + bulk actions -----
+    const header = document.createElement('div');
+    header.className = 'flex items-center justify-between gap-2 mb-2';
+    const h = document.createElement('div');
+    h.className = 'text-xs font-medium text-gray-600';
+    h.textContent = style.heading + ' — review (' + working.length + ')';
+    header.appendChild(h);
+
+    const actions = document.createElement('div');
+    actions.className = 'flex gap-2';
+    const acceptAll = document.createElement('button');
+    acceptAll.type = 'button';
+    acceptAll.className = 'text-xs px-2 py-1 rounded bg-indigo-600 text-white';
+    acceptAll.textContent = 'Accept all';
+    acceptAll.onclick = () => {
+      const remaining = working.slice();
+      if (typeof onAcceptAll === 'function') onAcceptAll(remaining);
+      else if (typeof onAccept === 'function') remaining.forEach(onAccept);
+      working.length = 0;
+      render();
+    };
+    const rejectAll = document.createElement('button');
+    rejectAll.type = 'button';
+    rejectAll.className = 'text-xs px-2 py-1 rounded border bg-white';
+    rejectAll.textContent = 'Reject all';
+    rejectAll.onclick = () => {
+      if (typeof onRejectAll === 'function') onRejectAll();
+      working.length = 0;
+      render();
+    };
+    actions.appendChild(acceptAll);
+    actions.appendChild(rejectAll);
+    header.appendChild(actions);
+    container.appendChild(header);
+
+    // ----- the suggestions -----
+    const ul = document.createElement('ul');
+    ul.setAttribute('role', 'list');
+    ul.className = 'flex flex-wrap gap-2';
+    working.forEach((item) => {
+      const li = document.createElement('li');
+      li.className = 'inline-flex items-center gap-1.5 border ' + style.chip + ' rounded-full pl-2 pr-1 py-0.5 text-xs';
+
+      if (style.spark) {
+        const s = document.createElement('span');
+        s.setAttribute('aria-hidden', 'true');
+        s.textContent = '✨';
+        li.appendChild(s);
+      }
+      const label = document.createElement('span');
+      label.textContent = item.display + (item.code ? ' (' + item.code + ')' : '');
+      li.appendChild(label);
+
+      const accept = document.createElement('button');
+      accept.type = 'button';
+      accept.className = 'opacity-80 hover:opacity-100 font-semibold';
+      accept.textContent = '✓';
+      accept.setAttribute('aria-label', 'Accept ' + (item.display || item.code));
+      accept.onclick = () => { if (typeof onAccept === 'function') onAccept(item); remove(item); render(); };
+
+      const reject = document.createElement('button');
+      reject.type = 'button';
+      reject.className = 'opacity-70 hover:opacity-100';
+      reject.textContent = '✕';
+      reject.setAttribute('aria-label', 'Reject ' + (item.display || item.code));
+      reject.onclick = () => { if (typeof onReject === 'function') onReject(item); remove(item); render(); };
+
+      li.appendChild(accept);
+      li.appendChild(reject);
+      ul.appendChild(li);
+    });
+    container.appendChild(ul);
+  }
+
+  render();
+}
+
+/** Disable a button and swap its label to a loading indicator; restores on false. */
+export function setLoadingState(buttonEl, isLoading, loadingText = 'Working…') {
+  if (!buttonEl) return;
+  if (isLoading) {
+    if (buttonEl.dataset.originalLabel == null) buttonEl.dataset.originalLabel = buttonEl.textContent;
+    buttonEl.disabled = true;
+    buttonEl.classList.add('btn-disabled');
+    buttonEl.textContent = '⏳ ' + loadingText;
+  } else {
+    buttonEl.disabled = false;
+    buttonEl.classList.remove('btn-disabled');
+    if (buttonEl.dataset.originalLabel != null) {
+      buttonEl.textContent = buttonEl.dataset.originalLabel;
+      delete buttonEl.dataset.originalLabel;
+    }
+  }
+}
+
+/** Non-alarming inline empty message (spec §4.7). */
+export function renderEmptyState(container, message) {
+  if (!container) return;
+  container.classList.remove('hidden');
+  container.replaceChildren();
+  const p = document.createElement('p');
+  p.className = 'text-sm text-gray-500';
+  p.textContent = message;
+  container.appendChild(p);
+}
+
+/** Inline error with a Retry button (spec §4.7). Must not block the rest of the form. */
+export function renderErrorState(container, message, onRetry) {
+  if (!container) return;
+  container.classList.remove('hidden');
+  container.replaceChildren();
+  const box = document.createElement('div');
+  box.className = 'flex items-center gap-3 text-sm text-red-700 bg-red-50 border border-red-200 rounded p-2';
+  const msg = document.createElement('span');
+  msg.textContent = message;
+  box.appendChild(msg);
+  if (typeof onRetry === 'function') {
+    const retry = document.createElement('button');
+    retry.type = 'button';
+    retry.className = 'ml-auto text-xs px-2 py-1 rounded border bg-white';
+    retry.textContent = 'Retry';
+    retry.onclick = onRetry;
+    box.appendChild(retry);
+  }
+  container.appendChild(box);
+}
+
+// ----- Phase 4 (decision support) stubs — implemented in that phase. -----
+export function renderAdvisoryPanel(/* { container, findings, onAddTest, onDismiss } */) {
+  console.warn('ai-ui.renderAdvisoryPanel is a Phase 4 stub — not implemented yet.');
+}
+
+export function openSeriousReviewModal(/* { findings, advisoryFindings } */) {
+  console.warn('ai-ui.openSeriousReviewModal is a Phase 4 stub — not implemented yet.');
+  return Promise.resolve({ action: 'proceed' });
+}

--- a/eRequest-placer-AI/modules/ai-ui.js
+++ b/eRequest-placer-AI/modules/ai-ui.js
@@ -25,10 +25,11 @@ const KIND_STYLES = {
  * @param {(item:object)=>void} [o.onReject]
  * @param {(remaining:object[])=>void} [o.onAcceptAll]
  * @param {()=>void} [o.onRejectAll]
+ * @param {(remaining:number)=>void} [o.onCountChange] invoked after each render with the remaining count
  * @param {'reason'|'test'|'finding'} [o.kind]
  */
 export function renderSuggestionReviewList({
-  container, items, onAccept, onReject, onAcceptAll, onRejectAll, kind = 'reason',
+  container, items, onAccept, onReject, onAcceptAll, onRejectAll, onCountChange, kind = 'reason',
 }) {
   if (!container) return;
   const style = KIND_STYLES[kind] || KIND_STYLES.reason;
@@ -38,7 +39,11 @@ export function renderSuggestionReviewList({
 
   function render() {
     container.replaceChildren();
-    if (!working.length) { container.classList.add('hidden'); return; }
+    if (!working.length) {
+      container.classList.add('hidden');
+      if (typeof onCountChange === 'function') onCountChange(0);
+      return;
+    }
     container.classList.remove('hidden');
 
     // ----- header: count + bulk actions -----
@@ -113,6 +118,7 @@ export function renderSuggestionReviewList({
       ul.appendChild(li);
     });
     container.appendChild(ul);
+    if (typeof onCountChange === 'function') onCountChange(working.length);
   }
 
   render();

--- a/eRequest-placer-AI/modules/reason-tags.js
+++ b/eRequest-placer-AI/modules/reason-tags.js
@@ -9,18 +9,46 @@ export function renderReasonTags() {
   const wrap = document.querySelector('#notes-tags');
   wrap.innerHTML = '';
   state.reasonTags.forEach((t, idx) => {
+    const isAi = t.source === 'ai';
     const chip = document.createElement('span');
-    chip.className = 'inline-flex items-center gap-1.5 border border-emerald-100 bg-emerald-50 text-emerald-800 rounded-full px-2 py-0.5 text-xs';
-    chip.innerHTML = '<span>' + t.display + '</span>';
+    // AI-derived tags are indigo + ✨ so they are visibly distinct from the
+    // emerald manual tags; manual styling is unchanged.
+    chip.className = isAi
+      ? 'inline-flex items-center gap-1.5 border border-indigo-200 bg-indigo-50 text-indigo-800 rounded-full px-2 py-0.5 text-xs'
+      : 'inline-flex items-center gap-1.5 border border-emerald-100 bg-emerald-50 text-emerald-800 rounded-full px-2 py-0.5 text-xs';
+    if (isAi) {
+      const spark = document.createElement('span');
+      spark.setAttribute('aria-hidden', 'true');
+      spark.textContent = '✨';
+      chip.appendChild(spark);
+    }
+    // textContent (not innerHTML) — display may be AI-sourced.
+    const label = document.createElement('span');
+    label.textContent = t.display;
+    chip.appendChild(label);
     const x = document.createElement('button');
     x.type = 'button';
     x.textContent = '✕';
     x.className = 'opacity-70 hover:opacity-100';
+    x.setAttribute('aria-label', 'Remove ' + (t.display || 'reason'));
     x.onclick = () => { state.reasonTags.splice(idx, 1); renderReasonTags(); };
     chip.appendChild(x);
     wrap.appendChild(chip);
   });
   computeAndRenderSuggestions();
+}
+
+// Add a reason tag (deduped by code+system) and re-render. Shared by the manual
+// autocomplete and the AI accept path. `source` ('manual' | 'ai') drives chip
+// styling only — it is NOT serialised into the FHIR bundle (buildReasonCodeArray
+// reads only system/code/display). Returns true if added, false if a duplicate.
+export function addReasonTag({ system, code, display, source = 'manual' }) {
+  const sys = system || 'http://snomed.info/sct';
+  if (!code) return false;
+  if (state.reasonTags.some((t) => t.code === code && t.system === sys)) return false;
+  state.reasonTags.push({ system: sys, code, display: display || code, source });
+  renderReasonTags();
+  return true;
 }
 
 export function buildReasonCodeArray() {
@@ -68,10 +96,7 @@ export function showReasonSuggestions(items) {
       const system = it.system || 'http://snomed.info/sct';
       const display = it.display || it.code;
 
-      if (!state.reasonTags.some((t) => t.code === code && t.system === system)) {
-        state.reasonTags.push({ system, code, display });
-        renderReasonTags();
-      }
+      addReasonTag({ system, code, display }); // source defaults to 'manual'
 
       const notes = document.getElementById('clinical-notes');
       const start = notes.selectionStart;


### PR DESCRIPTION
Closes #15. Builds on the Phase 1 substrate (#14).

A **"✨ Suggest codes"** button beside Clinical Notes derives SNOMED CT reason codes from the free-text notes via the shared agent loop, with an accept/reject review list before anything becomes a reason tag. The manual autocomplete on the same textarea is **unchanged** and remains the fallback (spec §4.7, §10.9).

## What's here

**New `modules/ai-reason-coding.js`** — `suggestReasonCodes()`:
- Gathers notes + age (from DOB) + sex + pregnancy; composes the spec §4.5 prompt with `{reason_ecl}` substituted.
- Runs `runAgent` with `getTools()`; **`search_concepts` is hard-coerced to `REASON_ECL`** regardless of what the model passes (defence in depth).
- Re-confirms every returned code is in-scope (`searchConcepts` by display within `REASON_ECL`, keep only if the code is present) — drops hallucinations even after a search (spec §3.4, §10.3).
- Returns `{ codes, error }`; degrades to an inline error, never blocks the form.

**New `modules/ai-ui.js`** (shared, reused by Phases 3–4) — `renderSuggestionReviewList` (indigo + ✨ chips, accept/reject + bulk), `setLoadingState`, `renderEmptyState`, `renderErrorState`, and Phase 4 stubs. Pure DOM, all `textContent`.

**`modules/reason-tags.js`** — extracted/exported `addReasonTag({system,code,display,source})`; AI-accepted tags render indigo, manual stay emerald (unchanged). `source` is UI-only.

**`index.html` / `app.js`** — `.ai-feature-controls` button row + `#ai-codes-review`; input gating (disabled when notes empty), click → review, accept/accept-all/reject wiring.

## FHIR parity
Bundle construction is untouched — `buildReasonCodeArray` reads only `system/code/display`, and `suggestions.js` reads only `system/code`, so the `source` field never reaches the bundle.

## Verification
- `node --check` + export-graph on all changed/new files.
- **Integration test** (fetch-level stub of the agent + Ontoserver): hallucinated code dropped by the in-scope confirmation; `search_concepts` ECL coercion verified (REASON_ECL used even when the model passes a bogus ECL); empty → `{codes:[],error:null}`; 401 → readable error, no codes; `ageFromDob` correct.
- **Edge headless boot**: clean load, button row + review div present, `#ai-suggest-codes` disabled by default, banner `backend = mcp · model = …`.

## Key decisions
1. **Accepted AI codes render indigo in `#notes-tags`** (verification step 2) via an optional `source` field — bundle unaffected.
2. **In-scope confirmation requires the candidate code to appear** in the display-search results (stronger than "any result"), to actually catch hallucinations.
3. **Safe DOM** (`textContent`) for AI-sourced display text.
4. Master-toggle show/hide of `.ai-feature-controls` deferred to Phase 5 (PLAN.md §147) — only the class is added here.

## Needs a key (as in Phase 1)
The live click-through (issue verification steps 1–8) needs an OpenRouter key in AI Settings; I ran everything automatable and left the keyed run for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)