### PR TITLE
feat(ai-proxy): OpenRouter Cloudflare Worker proxy + wire app to deployed URL

### DIFF
--- a/ai-proxy/.gitignore
+++ b/ai-proxy/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.wrangler/
+.dev.vars

--- a/ai-proxy/README.md
+++ b/ai-proxy/README.md
@@ -1,0 +1,110 @@
+# callistemon-ai-proxy
+
+A minimal Cloudflare Worker that proxies OpenRouter chat-completion requests for
+the callistemon static apps (starting with `eRequest-placer-AI`).
+
+## Why this exists
+
+GitHub Pages can't run server-side code, but putting the OpenRouter API key in
+browser-readable JS is unacceptable — DevTools would leak it, and every visitor
+would burn the deployer's credits. This Worker is the smallest piece of
+server-side code that lets visitors use the AI features without each bringing
+their own key:
+
+- holds `OPENROUTER_API_KEY` as a Cloudflare **secret** (never in source);
+- accepts `POST /chat/completions` from an allow-listed origin with **no** auth
+  header;
+- adds `Authorization: Bearer <secret>` and forwards to OpenRouter;
+- applies an Origin allowlist + per-IP hourly rate limit to bound abuse.
+
+The app's hybrid client (`eRequest-placer-AI/modules/openrouter-client.js`) uses
+this proxy as the **default** route. Users who prefer their own key can tick
+"Use my own OpenRouter key" in AI Settings to bypass the proxy entirely.
+
+## Files
+
+| File            | Purpose                                                        |
+| --------------- | -------------------------------------------------------------- |
+| `worker.js`     | The Worker source. Edit `ALLOWED_ORIGINS` to change allowlist. |
+| `wrangler.toml` | Worker name, entrypoint, KV binding.                           |
+| `.gitignore`    | Excludes `node_modules/`, `.wrangler/`, `.dev.vars`.           |
+
+## Prerequisites
+
+- A Cloudflare account (free tier — Workers free plan allows 100K requests/day).
+- An OpenRouter API key (`sk-or-v1-...`).
+- Wrangler CLI: `npm install -g wrangler`.
+
+## Deploy
+
+Run these from this directory (`ai-proxy/`):
+
+```sh
+# 1. Authenticate Wrangler with your Cloudflare account (opens a browser).
+wrangler login
+
+# 2. Create the KV namespace for rate-limit counters.
+#    (On wrangler < 3.60 the command is `wrangler kv:namespace create RATE_KV`.)
+wrangler kv namespace create RATE_KV
+#    Copy the returned id into the `id = "..."` field in wrangler.toml.
+
+# 3. Store the OpenRouter key as a secret (paste the sk-or-v1-... key when prompted).
+wrangler secret put OPENROUTER_API_KEY
+
+# 4. Deploy.
+wrangler deploy
+```
+
+Note the published URL, e.g. `https://callistemon-ai-proxy.<account>.workers.dev`.
+
+## Wire the app to the deployed URL
+
+Once the Worker is live and verified (below), update
+`eRequest-placer-AI/config.js` `AI_DEFAULTS`:
+
+```js
+PROXY_BASE_URL: 'https://callistemon-ai-proxy.<account>.workers.dev',
+PROXY_DEPLOYED: true,
+```
+
+`PROXY_DEPLOYED` gates the proxy route in `openrouter-client.js`: while `false`,
+the client refuses to POST clinical free-text to the (placeholder) proxy host.
+Only flip it to `true` after the deploy is verified.
+
+## Verify
+
+1. **Happy path** — from DevTools on a tab whose origin is
+   `https://mattcordell.github.io`:
+   ```js
+   await fetch('<proxy-url>/chat/completions', {
+     method: 'POST',
+     headers: { 'Content-Type': 'application/json' },
+     body: JSON.stringify({
+       model: 'google/gemma-4-31b-it:free',
+       messages: [{ role: 'user', content: 'ping' }],
+     }),
+   }).then(r => r.text());
+   ```
+   Expect a chat-completion JSON response.
+2. **Foreign origin** — repeat from a non-allow-listed origin (e.g.
+   `https://example.com`): expect **403**.
+3. **Rate limit** — hit the proxy 51 times within one hour from the same IP:
+   expect **429** on the 51st.
+4. **Secret hygiene** — inspect the deployed source in the Cloudflare dashboard:
+   confirm no API key in source and that the `OPENROUTER_API_KEY` secret is set.
+
+## Local development
+
+`wrangler dev` runs the Worker on `http://localhost:8787` using the same code
+path. Uncomment the `http://localhost:8000` line in `ALLOWED_ORIGINS`
+(`worker.js`) for the duration of local testing — that's the origin of the app's
+documented dev server (`python -m http.server 8000`).
+
+## Out of scope (intentionally)
+
+This proxy is deliberately minimal. Do **not** add streaming support, response
+caching, or model routing — those are application concerns and would bloat the
+Worker. Authentication is Origin + rate-limit only; if abuse becomes a real
+problem, add a shared-secret query parameter the app supplies and the Worker
+checks (still spoofable by anyone who reads the deployed app JS, but raises the
+bar another notch).

--- a/ai-proxy/README.md
+++ b/ai-proxy/README.md
@@ -15,7 +15,10 @@ their own key:
 - accepts `POST /chat/completions` from an allow-listed origin with **no** auth
   header;
 - adds `Authorization: Bearer <secret>` and forwards to OpenRouter;
-- applies an Origin allowlist + per-IP hourly rate limit to bound abuse.
+- applies an Origin allowlist + per-IP hourly rate limit to bound abuse;
+- **serves free models only** — rejects any request whose `model` slug doesn't
+  end in `:free` with a 400. The proxy bills the deployer's key, so paid models
+  must go via the user's own key (the direct route).
 
 The app's hybrid client (`eRequest-placer-AI/modules/openrouter-client.js`) uses
 this proxy as the **default** route. Users who prefer their own key can tick
@@ -104,7 +107,11 @@ documented dev server (`python -m http.server 8000`).
 
 This proxy is deliberately minimal. Do **not** add streaming support, response
 caching, or model routing — those are application concerns and would bloat the
-Worker. Authentication is Origin + rate-limit only; if abuse becomes a real
-problem, add a shared-secret query parameter the app supplies and the Worker
-checks (still spoofable by anyone who reads the deployed app JS, but raises the
-bar another notch).
+Worker. Authentication is Origin + rate-limit + free-model-only; if abuse becomes
+a real problem, add a shared-secret query parameter the app supplies and the
+Worker checks (still spoofable by anyone who reads the deployed app JS, but
+raises the bar another notch).
+
+**Recommended:** give the OpenRouter key behind the secret a hard spend cap (or
+no payment method on the account) so the worst case for any bypass is exhausting
+the free quota, not real charges.

--- a/ai-proxy/worker.js
+++ b/ai-proxy/worker.js
@@ -45,10 +45,7 @@ export default {
     const rateKey = `rl:${ip}:${hour}`;
     const current = parseInt((await env.RATE_KV.get(rateKey)) || '0', 10);
     if (current >= RATE_LIMIT_PER_HOUR) {
-      return new Response(JSON.stringify({ error: 'Rate limit exceeded' }), {
-        status: 429,
-        headers: { 'Content-Type': 'application/json', ...corsHeaders(origin) },
-      });
+      return jsonResponse(429, { error: 'Rate limit exceeded' }, origin);
     }
     await env.RATE_KV.put(rateKey, String(current + 1), { expirationTtl: 3700 });
 
@@ -57,6 +54,23 @@ export default {
     // forwarding `request.body` directly (some runtimes require a `duplex` hint
     // when the init contains a stream body). A buffered string is unambiguous.
     const reqBody = await request.text();
+
+    // Model allowlist. This managed proxy bills the DEPLOYER's key, so it serves
+    // FREE models only (slug ending in ":free"); paid models require the user's
+    // own key via the direct route. The Origin check above is spoofable by any
+    // non-browser client, so this server-side guard is the real bound preventing
+    // someone from billing an expensive model to the deployer.
+    let parsed;
+    try {
+      parsed = JSON.parse(reqBody);
+    } catch (_e) {
+      return jsonResponse(400, { error: 'Invalid JSON body' }, origin);
+    }
+    if (typeof parsed.model !== 'string' || !parsed.model.endsWith(':free')) {
+      return jsonResponse(400, {
+        error: 'Only free models (slug ending in ":free") are allowed via the managed proxy. Use your own OpenRouter key for paid models.',
+      }, origin);
+    }
 
     // Forward to OpenRouter
     let upstream;
@@ -71,11 +85,9 @@ export default {
         },
         body: reqBody,
       });
-    } catch (e) {
-      return new Response(JSON.stringify({ error: 'Upstream unreachable', detail: String(e) }), {
-        status: 502,
-        headers: { 'Content-Type': 'application/json', ...corsHeaders(origin) },
-      });
+    } catch (_e) {
+      // Don't echo the internal error detail back to the caller.
+      return jsonResponse(502, { error: 'Upstream unreachable' }, origin);
     }
 
     // Pass body + status through; replace headers (preserve content-type, add CORS)
@@ -89,11 +101,22 @@ export default {
   },
 };
 
+function jsonResponse(status, obj, origin) {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders(origin) },
+  });
+}
+
 function corsHeaders(origin) {
   return {
     'Access-Control-Allow-Origin': ALLOWED_ORIGINS.has(origin) ? origin : '',
     'Access-Control-Allow-Methods': 'POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
+    // Allow the attribution headers too, so any client sending OpenRouter-style
+    // headers passes preflight (the app itself only sends them on the direct route).
+    'Access-Control-Allow-Headers': 'Content-Type, HTTP-Referer, X-Title',
     'Access-Control-Max-Age': '86400',
+    // ACAO is origin-dependent; Vary prevents a shared cache reusing it cross-origin.
+    'Vary': 'Origin',
   };
 }

--- a/ai-proxy/worker.js
+++ b/ai-proxy/worker.js
@@ -1,0 +1,99 @@
+// Cloudflare Worker proxying OpenRouter chat completions for callistemon AI apps.
+//
+// Holds the OpenRouter API key as a server-side secret so static GitHub Pages
+// apps (e.g. eRequest-placer-AI) can use the AI features without each visitor
+// bringing their own key. The browser POSTs to this worker with NO auth header;
+// the worker adds `Authorization: Bearer <secret>` and forwards to OpenRouter.
+//
+// Secrets (set via `wrangler secret put`):
+//   OPENROUTER_API_KEY   The actual sk-or-v1-... key
+//
+// Bindings (configured in wrangler.toml):
+//   RATE_KV              KV namespace used for per-IP rate-limit counters
+//
+// See README.md in this directory for the full deploy + verification runbook.
+
+const ALLOWED_ORIGINS = new Set([
+  'https://mattcordell.github.io',
+  // 'http://localhost:8000', // uncomment for local dev (the app's documented dev server)
+]);
+
+const RATE_LIMIT_PER_HOUR = 50; // per source IP
+
+export default {
+  async fetch(request, env) {
+    const origin = request.headers.get('Origin') || '';
+
+    // CORS preflight
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { headers: corsHeaders(origin) });
+    }
+    if (request.method !== 'POST') {
+      return new Response('Method not allowed', { status: 405, headers: corsHeaders(origin) });
+    }
+
+    // Origin allowlist (best-effort — Origin is set by browsers, spoofable by other clients)
+    if (!ALLOWED_ORIGINS.has(origin)) {
+      return new Response('Origin not allowed', { status: 403, headers: corsHeaders(origin) });
+    }
+
+    // Per-IP rate limiting via KV. KV is eventually consistent, so this is an
+    // approximate (best-effort) limit — adequate for bounding casual abuse of a
+    // demo, not a hard quota.
+    const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
+    const hour = new Date().toISOString().slice(0, 13); // YYYY-MM-DDTHH
+    const rateKey = `rl:${ip}:${hour}`;
+    const current = parseInt((await env.RATE_KV.get(rateKey)) || '0', 10);
+    if (current >= RATE_LIMIT_PER_HOUR) {
+      return new Response(JSON.stringify({ error: 'Rate limit exceeded' }), {
+        status: 429,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders(origin) },
+      });
+    }
+    await env.RATE_KV.put(rateKey, String(current + 1), { expirationTtl: 3700 });
+
+    // Buffer the request body before forwarding. The chat-completion payload is
+    // small JSON, and buffering sidesteps the streaming-passthrough pitfalls of
+    // forwarding `request.body` directly (some runtimes require a `duplex` hint
+    // when the init contains a stream body). A buffered string is unambiguous.
+    const reqBody = await request.text();
+
+    // Forward to OpenRouter
+    let upstream;
+    try {
+      upstream = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${env.OPENROUTER_API_KEY}`,
+          'Content-Type': 'application/json',
+          'HTTP-Referer': origin,
+          'X-Title': 'callistemon-ai',
+        },
+        body: reqBody,
+      });
+    } catch (e) {
+      return new Response(JSON.stringify({ error: 'Upstream unreachable', detail: String(e) }), {
+        status: 502,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders(origin) },
+      });
+    }
+
+    // Pass body + status through; replace headers (preserve content-type, add CORS)
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: {
+        'Content-Type': upstream.headers.get('Content-Type') || 'application/json',
+        ...corsHeaders(origin),
+      },
+    });
+  },
+};
+
+function corsHeaders(origin) {
+  return {
+    'Access-Control-Allow-Origin': ALLOWED_ORIGINS.has(origin) ? origin : '',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400',
+  };
+}

--- a/ai-proxy/wrangler.toml
+++ b/ai-proxy/wrangler.toml
@@ -1,0 +1,9 @@
+name = "callistemon-ai-proxy"
+main = "worker.js"
+compatibility_date = "2026-05-01"
+
+# Per-IP rate-limit counters. Create the namespace, then paste the returned id:
+#   wrangler kv namespace create RATE_KV
+[[kv_namespaces]]
+binding = "RATE_KV"
+id = "9cce35be3d67480390d0d078b44b277c"

--- a/eRequest-placer-AI/config.js
+++ b/eRequest-placer-AI/config.js
@@ -68,14 +68,13 @@ export const CAT = {
 // so editing a default here propagates unless the user has overridden that key.
 export const AI_DEFAULTS = {
   // Default route: managed Cloudflare Worker proxy that holds the OpenRouter API
-  // key as a secret. Visitors don't need their own key. Replace this placeholder
-  // with the real deployed worker URL once the proxy issue is closed.
-  PROXY_BASE_URL: 'https://callistemon-ai-proxy.workers.dev',
-  // Guard: the host above is an UNCLAIMED workers.dev placeholder until issue #20
-  // deploys the worker. While false, openrouter-client refuses the proxy route
-  // (it would POST clinical free-text to an unowned domain) and tells the user to
-  // switch on their own key. Flip to true when #20 ships the real URL.
-  PROXY_DEPLOYED: false,
+  // key as a secret, so visitors don't need their own key. Deployed per issue #20
+  // (source in /ai-proxy). The worker allow-lists mattcordell.github.io and rate-
+  // limits per IP; it injects the key upstream so no auth header is sent from here.
+  PROXY_BASE_URL: 'https://callistemon-ai-proxy.callistemon.workers.dev',
+  // Guard checked by openrouter-client before using the proxy route. Now true: the
+  // worker above is deployed and owned, so POSTing clinical free-text to it is safe.
+  PROXY_DEPLOYED: true,
   // Fallback route: direct OpenRouter, used only when USE_OWN_OPENROUTER_KEY is
   // true (the "Use my own OpenRouter key" toggle in AI Settings).
   OPENROUTER_BASE: 'https://openrouter.ai/api/v1',

--- a/eRequest-placer-AI/modules/openrouter-client.js
+++ b/eRequest-placer-AI/modules/openrouter-client.js
@@ -48,12 +48,7 @@ export async function chatCompletion({ model, messages, tools, signal } = {}) {
   const base = ((useOwnKey ? s.OPENROUTER_BASE : s.PROXY_BASE_URL) || '').replace(/\/+$/, '');
   const url = base + '/chat/completions';
 
-  const headers = {
-    'Content-Type': 'application/json',
-    // OpenRouter attribution headers (harmless on the proxy route too).
-    'HTTP-Referer': (typeof location !== 'undefined' && location.origin) || 'https://callistemon',
-    'X-Title': 'callistemon-ai',
-  };
+  const headers = { 'Content-Type': 'application/json' };
 
   if (useOwnKey) {
     const key = (s.OPENROUTER_API_KEY || '').trim();
@@ -63,6 +58,12 @@ export async function chatCompletion({ model, messages, tools, signal } = {}) {
         { kind: 'unauthorized' });
     }
     headers.Authorization = 'Bearer ' + key;
+    // OpenRouter attribution headers — only on the direct route. On the proxy
+    // route the worker sets HTTP-Referer/X-Title itself when forwarding upstream,
+    // so sending them from the browser is redundant AND, being non-safelisted
+    // custom headers, would trip the CORS preflight against the worker.
+    headers['HTTP-Referer'] = (typeof location !== 'undefined' && location.origin) || 'https://callistemon';
+    headers['X-Title'] = 'callistemon-ai';
   } else if (!s.PROXY_DEPLOYED) {
     // Refuse the proxy route until issue #20 deploys the worker: PROXY_BASE_URL is
     // an unclaimed workers.dev placeholder, so POSTing clinical free-text there is


### PR DESCRIPTION
﻿## What

Adds the managed **OpenRouter proxy** (Cloudflare Worker) from #20 and wires the `eRequest-placer-AI` app to the deployed URL, enabling the default "managed key" route — visitors no longer need their own OpenRouter key for the demo.

### `/ai-proxy` (new)
- `worker.js` — holds `OPENROUTER_API_KEY` as a Cloudflare secret, allow-lists `mattcordell.github.io`, per-IP hourly rate limit (50), forwards `POST /chat/completions` to OpenRouter with the auth header added server-side. **Buffers the request body** (`await request.text()`) rather than forwarding the raw `request.body` stream — avoids the `duplex`-hint pitfall some runtimes hit on stream bodies.
- `wrangler.toml` — name/entrypoint + `RATE_KV` binding (real namespace id).
- `README.md` — deploy + verify runbook.
- `.gitignore`.

### App wiring
- `config.js`: `PROXY_BASE_URL` → `https://callistemon-ai-proxy.callistemon.workers.dev`, `PROXY_DEPLOYED` → `true`. The latter is the guard in `openrouter-client.js` that previously refused the proxy route while the host was an unclaimed placeholder.

## Verification (against the live worker)
- Foreign origin (`example.com`) → **403** ✓
- `OPTIONS` preflight (allow-listed origin) → **200** with `Access-Control-Allow-Origin: https://mattcordell.github.io`, `Allow-Methods: POST, OPTIONS` ✓
- Allow-listed happy-path `POST` → **200**, real chat-completion (`"Pong!"`, `cost:0` free model) — confirms secret injection + upstream forwarding end-to-end ✓

## Acceptance criteria (#20)
- [x] Worker deployed to a stable URL
- [x] `OPENROUTER_API_KEY` set as a Cloudflare secret (never in source)
- [x] `RATE_KV` namespace created and bound
- [x] `mattcordell.github.io` allow-listed; other origins → 403
- [~] Per-IP hourly rate limit **implemented** (KV counter + 429 path) - code verified, not exercised by firing 51 requests
- [x] OPTIONS preflight returns CORS headers
- [x] Real `chat/completions` request succeeds end-to-end
- [x] `AI_DEFAULTS.PROXY_BASE_URL` updated to the deployed URL

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)
