### PR TITLE
feat(eRequest-placer-AI): Feature C - AI-enhanced decision support (Phase 4)

### DIFF
--- a/eRequest-placer-AI/app.js
+++ b/eRequest-placer-AI/app.js
@@ -43,7 +43,11 @@ import { suggestReasonCodes } from './modules/ai-reason-coding.js';
 import { suggestTests } from './modules/ai-test-selection.js';
 import {
   renderSuggestionReviewList, setLoadingState, renderEmptyState, renderErrorState,
+  renderAdvisoryPanel, openSeriousReviewModal,
 } from './modules/ai-ui.js';
+import {
+  shouldRunDecisionSupport, evaluateRequest, appendAcknowledgementNote,
+} from './modules/ai-decision-support.js';
 
 // JSON viewer instance — owned by this module (boot sets it). Domain modules
 // like bundle-builder.js are no longer aware of it; the caller of buildBundle()
@@ -231,6 +235,58 @@ function initTestSelection() {
   }
 
   btn.addEventListener('click', run);
+}
+
+// Feature C wiring: the pre-send hook (spec §C.3 / §C.9). Invoked by the send
+// button between bundle construction and POST. Skips silently when not
+// applicable; on a serious result, blocks the send behind the Tier 2 modal and
+// records the override on the bundle if the clinician proceeds.
+const SCT = 'http://snomed.info/sct';
+
+async function decisionSupportPreHook(bundle) {
+  const notes = (document.getElementById('clinical-notes').value || '');
+  if (!shouldRunDecisionSupport(bundle, notes)) return { proceed: true };
+
+  const { result, error } = await evaluateRequest(bundle);
+
+  // Unavailable -> brief inline notice, send proceeds (spec §C.3, §C.9).
+  if (error || !result) {
+    showStatus('Decision support unavailable — please review your request before sending');
+    return { proceed: true };
+  }
+  if (result.overall_severity === 'none') return { proceed: true };
+
+  // Tier 1: always show the advisory panel for any findings (spec §C.9).
+  const panel = document.getElementById('ai-advisory-panel');
+  const onAddTest = async (code) => {
+    let display = code;
+    try {
+      const res = await lookupConcept({ system: SCT, code });
+      const hit = Array.isArray(res) ? res[0] : null;
+      if (hit && hit.display) display = hit.display;
+    } catch (_e) { /* fall back to the bare code as display */ }
+    // kind isn't recoverable from a bare SNOMED id — default PATH (demo limitation).
+    addSelectedTest({ system: SCT, code, display, kind: 'PATH' });
+    showStatus('Added ' + display);
+  };
+  renderAdvisoryPanel({
+    container: panel,
+    findings: result.findings,
+    onAddTest,
+    onDismiss: () => { if (panel) panel.classList.add('hidden'); },
+  });
+
+  // Tier 2: serious findings block the send behind the review modal.
+  if (result.overall_severity === 'serious') {
+    const seriousFindings = result.findings.filter((f) => f.severity === 'serious');
+    const advisoryFindings = result.findings.filter((f) => f.severity === 'advisory');
+    const choice = await openSeriousReviewModal({ findings: seriousFindings, advisoryFindings });
+    if (choice === 'edit') return { proceed: false };
+    appendAcknowledgementNote(bundle, seriousFindings); // spec §C.10
+    return { proceed: true };
+  }
+
+  return { proceed: true };
 }
 
 function boot() {
@@ -435,9 +491,12 @@ function boot() {
 
   // ----- Send button -----
   // `onBundleBuilt` updates the JSON viewer so users who skip "Build" still see
-  // the bundle they sent. Phase 4 will additionally pass `preSendHook` here for
-  // decision-support gating.
-  initSendButton({ onBundleBuilt: (bundle) => viewer.show(bundle) });
+  // the bundle they sent. `preSendHook` is Feature C decision support (spec §C.3):
+  // it gates the POST and may mutate the bundle (acknowledgement note, §C.10).
+  initSendButton({
+    onBundleBuilt: (bundle) => viewer.show(bundle),
+    preSendHook: decisionSupportPreHook,
+  });
 
   // ----- Copy server response -----
   document.getElementById('copy-server-response').addEventListener('click', async (e) => {

--- a/eRequest-placer-AI/app.js
+++ b/eRequest-placer-AI/app.js
@@ -258,16 +258,19 @@ async function decisionSupportPreHook(bundle) {
 
   // Tier 1: always show the advisory panel for any findings (spec §C.9).
   const panel = document.getElementById('ai-advisory-panel');
-  const onAddTest = async (code) => {
+  const onAddTest = async (code, kind) => {
     let display = code;
     try {
       const res = await lookupConcept({ system: SCT, code });
       const hit = Array.isArray(res) ? res[0] : null;
       if (hit && hit.display) display = hit.display;
     } catch (_e) { /* fall back to the bare code as display */ }
-    // kind isn't recoverable from a bare SNOMED id — default PATH (demo limitation).
-    addSelectedTest({ system: SCT, code, display, kind: 'PATH' });
-    showStatus('Added ' + display);
+    // Use the category the model assigned to the suggestion; default PATH when it
+    // didn't specify one. Surface the chosen category in the confirmation so a
+    // defaulted (or wrong) categorisation is visible to the clinician.
+    const k = (kind === 'IMAG') ? 'IMAG' : 'PATH';
+    addSelectedTest({ system: SCT, code, display, kind: k });
+    showStatus('Added ' + display + (k === 'IMAG' ? ' (imaging)' : ' (pathology)'));
   };
   renderAdvisoryPanel({
     container: panel,

--- a/eRequest-placer-AI/index.html
+++ b/eRequest-placer-AI/index.html
@@ -412,6 +412,11 @@
       </div>
     </section>
 
+    <!-- Feature C: decision support Tier 1 advisory panel (spec §C.9). Populated
+         by ai-ui.renderAdvisoryPanel at Send. .ai-feature-controls is the
+         master-toggle hook (Phase 5). -->
+    <div id="ai-advisory-panel" class="hidden ai-feature-controls mb-3"></div>
+
     <!-- Selected tests -->
     <section class="bg-white p-4 rounded-2xl shadow">
       <h3 class="font-semibold mb-2">Selected Tests</h3>
@@ -523,6 +528,29 @@
   </div>
 
   <!-- Body Site Modal -->
+  <!-- Feature C: decision support Tier 2 serious-review modal (spec §C.9). Driven
+       by ai-ui.openSeriousReviewModal; Proceed stays disabled until the checkbox
+       is ticked. -->
+  <div id="ai-serious-backdrop" class="backdrop" style="display:none">
+    <div class="modal p-4" role="dialog" aria-modal="true" aria-labelledby="ai-serious-title" style="max-width:640px;width:100%">
+      <div class="border-b pb-2 mb-3">
+        <h3 id="ai-serious-title" class="text-lg font-semibold">Please review before sending</h3>
+        <p class="text-sm text-gray-500">Decision support has flagged the following as warranting review.</p>
+      </div>
+      <div id="ai-serious-body" class="space-y-3 max-h-[60vh] overflow-y-auto"></div>
+      <div class="mt-3 border-t pt-3">
+        <label class="flex items-center gap-2 text-sm">
+          <input type="checkbox" id="ai-serious-confirm">
+          I have reviewed these findings and wish to proceed
+        </label>
+        <div class="flex justify-end gap-2 mt-3">
+          <button id="ai-serious-edit" class="px-3 py-1.5 border rounded">Review and edit request</button>
+          <button id="ai-serious-proceed" class="px-3 py-1.5 bg-emerald-600 text-white rounded disabled:opacity-50" disabled>Proceed anyway</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div id="body-site-backdrop" class="backdrop" style="display:none">
     <div class="modal p-4" style="max-width:480px;width:100%">
       <div class="flex items-start justify-between gap-4 border-b pb-3">

--- a/eRequest-placer-AI/modules/ai-decision-support.js
+++ b/eRequest-placer-AI/modules/ai-decision-support.js
@@ -1,0 +1,211 @@
+// modules/ai-decision-support.js — Feature C: pre-send decision support.
+//
+// Runs as a distinct pipeline from Features A/B (spec §C.1): triggered at Send,
+// after the bundle is built, it evaluates the whole request across four
+// dimensions and returns a structured result that drives the two-tier UI
+// (advisory panel + serious-review modal). All output is advisory — the
+// clinician can always proceed (spec §C.1, §C.9).
+
+import { state } from './state.js';
+import { getAiSettings, isDecisionSupportEnabled } from './settings-ai.js';
+import { runAgent } from './ai-agent.js';
+import { getTools, searchConcepts, lookupConcept } from './ontoserver-tools.js';
+import { gatherPatientContext, combineGuidance } from './ai-context.js';
+import { fetchAndSummarisePrior } from './prior-requests.js';
+
+const VALID_SEVERITY = new Set(['advisory', 'serious']);
+const VALID_DIMENSION = new Set(['appropriateness', 'suggestion', 'duplicate', 'context']);
+
+// Spec §C.7 (system prompt) + §C.8 (output format). {guidelines} is substituted
+// with the operator's COMMON + decision-support guidance (combineGuidance); it is
+// '(none)' when both are empty so the slot never dangles, and the feature then
+// runs on the model's general clinical training alone (spec §C.4).
+const SYSTEM_PROMPT = [
+  'You are a clinical decision support assistant for a general practice requesting clinician. You will be given a draft pathology or radiology request and must evaluate it across four dimensions: appropriateness, missed tests, duplicates, and context completeness.',
+  '',
+  'Apply the following clinical guidelines and local rules as authoritative where they conflict with your general training:',
+  '{guidelines}',
+  '',
+  'For each finding, assign a severity:',
+  '- "advisory" — informational, non-urgent; the clinician may proceed without action.',
+  '- "serious" — warrants clinician review before sending; one or more of: the test is clinically inappropriate for the patient\'s demographics; the combination of tests or implied diagnoses carries potential clinical risk; critical context is missing that would affect how the request is actioned; a high-risk test has been ordered without documented clinical justification.',
+  '',
+  'You have an Ontoserver tool (search_concepts / lookup_concept) available to validate a SNOMED concept if useful; using it is optional.',
+  '',
+  'Return a JSON object ONLY (no prose, no markdown) in exactly this shape:',
+  '{',
+  '  "overall_severity": "advisory | serious | none",',
+  '  "findings": [',
+  '    {',
+  '      "severity": "advisory | serious",',
+  '      "dimension": "appropriateness | suggestion | duplicate | context",',
+  '      "summary": "Brief plain-English summary, 1-2 sentences, for a clinician — no jargon, no alarm language",',
+  '      "detail": "Optional longer explanation",',
+  '      "related_tests": ["<SNOMED concept id from the current request this relates to>"]',
+  '    }',
+  '  ]',
+  '}',
+  'overall_severity is "serious" if any finding is serious, otherwise "advisory" if any findings exist, otherwise "none". findings may be an empty array. related_tests may be empty.',
+].join('\n');
+
+/**
+ * Gating per spec §C.3: run only when the toggle is on AND there is at least one
+ * test AND clinical notes are present.
+ */
+export function shouldRunDecisionSupport(bundle, clinicalNotes) {
+  if (!isDecisionSupportEnabled()) return false;
+  if (countServiceRequests(bundle) < 1) return false;
+  if (!String(clinicalNotes || '').trim()) return false;
+  return true;
+}
+
+/**
+ * Top-level evaluation invoked by the send pre-hook.
+ * @returns {Promise<{result: object|null, error: string|null}>}
+ */
+export async function evaluateRequest(bundle) {
+  try {
+    const s = getAiSettings();
+    const { selectedTests, clinicalNotes, reasonTags } = extractFromBundle(bundle);
+
+    // Prior requests only when the patient is server-resolved (has an id) — a
+    // newly-entered patient has nothing to query. Best-effort; never blocks.
+    const pid = state.currentPatientResource && state.currentPatientResource.id;
+    const priorRequests = pid ? await fetchAndSummarisePrior(pid) : [];
+
+    // Function replacer so a literal `$` in operator guidance isn't treated as a
+    // String.replace special pattern ($&, $1, …).
+    const guidance = combineGuidance(s.COMMON_PROMPT_SUPPLEMENTS, s.GUIDELINES_SUMMARY);
+    const systemPrompt = SYSTEM_PROMPT.replace('{guidelines}', () => guidance);
+
+    const userMessage = JSON.stringify({
+      selected_tests: selectedTests,
+      clinical_notes: clinicalNotes,
+      reason_tags: reasonTags,
+      patient: gatherPatientContext(),
+      prior_requests: priorRequests,
+    });
+
+    const toolImpl = {
+      search_concepts: (args) => searchConcepts(args),
+      lookup_concept: (args) => lookupConcept(args),
+    };
+
+    const { parsed, error } = await runAgent({
+      systemPrompt,
+      userMessage,
+      tools: getTools(),
+      toolImpl,
+      model: s.OPENROUTER_MODEL,
+    });
+
+    if (error) return { result: null, error };
+
+    const result = validateDecisionResult(parsed);
+    if (!result) return { result: null, error: 'Decision support returned an unrecognised response.' };
+    return { result, error: null };
+  } catch (e) {
+    if (e && e.name === 'AbortError') return { result: null, error: 'Cancelled.' };
+    return { result: null, error: String((e && e.message) || e) };
+  }
+}
+
+/**
+ * Validate + normalise the agent's parsed output against spec §C.8. Pure (no IO)
+ * so it can be unit-tested. Drops malformed findings, and derives
+ * overall_severity from the surviving findings rather than trusting the model's
+ * own field (keeps the contract: serious > advisory > none). Returns null only
+ * when the top-level shape is unusable.
+ */
+export function validateDecisionResult(parsed) {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const rawFindings = Array.isArray(parsed.findings) ? parsed.findings : [];
+
+  const findings = [];
+  for (const f of rawFindings) {
+    if (!f || typeof f !== 'object') continue;
+    if (!VALID_SEVERITY.has(f.severity)) continue;
+    if (!VALID_DIMENSION.has(f.dimension)) continue;
+    const summary = String(f.summary || '').trim();
+    if (!summary) continue;
+
+    const finding = { severity: f.severity, dimension: f.dimension, summary };
+    if (f.detail != null && String(f.detail).trim()) finding.detail = String(f.detail).trim();
+    if (Array.isArray(f.related_tests)) {
+      finding.related_tests = f.related_tests.map((t) => String(t)).filter(Boolean);
+    } else {
+      finding.related_tests = [];
+    }
+    findings.push(finding);
+  }
+
+  const overall_severity = findings.some((f) => f.severity === 'serious')
+    ? 'serious'
+    : (findings.length ? 'advisory' : 'none');
+
+  return { overall_severity, findings };
+}
+
+/**
+ * Spec §C.10: record that serious flags were reviewed and overridden by appending
+ * a note to every ServiceRequest in the bundle. Mutates in place; no profile or
+ * structural change.
+ */
+export function appendAcknowledgementNote(bundle, seriousFindings) {
+  const iso = new Date().toISOString();
+  const summaries = (seriousFindings || [])
+    .map((f) => (f && f.summary) || '')
+    .filter(Boolean)
+    .join('; ');
+  const text = 'Decision support flags reviewed and overridden by requesting clinician on '
+    + iso + (summaries ? ': ' + summaries : '');
+
+  forEachServiceRequest(bundle, (res) => {
+    if (!Array.isArray(res.note)) res.note = [];
+    res.note.push({ text });
+  });
+  return bundle;
+}
+
+// ----- bundle helpers -----
+
+function extractFromBundle(bundle) {
+  const selectedTests = [];
+  let clinicalNotes = '';
+  let reasonTags = [];
+
+  forEachServiceRequest(bundle, (res) => {
+    const coding = (res.code && Array.isArray(res.code.coding) && res.code.coding[0]) || null;
+    selectedTests.push({
+      code: coding ? (coding.code || null) : null,
+      display: (coding && coding.display) || (res.code && res.code.text) || null,
+    });
+    // Notes + reason codes are identical across this bundle's SRs (built once);
+    // capture from the first SR that carries them.
+    if (!clinicalNotes && Array.isArray(res.note) && res.note[0] && res.note[0].text) {
+      clinicalNotes = String(res.note[0].text);
+    }
+    if (!reasonTags.length && Array.isArray(res.reasonCode) && res.reasonCode.length) {
+      reasonTags = res.reasonCode.map((rc) => {
+        const c = (rc && Array.isArray(rc.coding) && rc.coding[0]) || null;
+        return { code: c ? (c.code || null) : null, display: (c && c.display) || (rc && rc.text) || null };
+      });
+    }
+  });
+
+  return { selectedTests, clinicalNotes, reasonTags };
+}
+
+function forEachServiceRequest(bundle, fn) {
+  const entries = (bundle && Array.isArray(bundle.entry)) ? bundle.entry : [];
+  for (const e of entries) {
+    const res = e && e.resource;
+    if (res && res.resourceType === 'ServiceRequest') fn(res);
+  }
+}
+
+function countServiceRequests(bundle) {
+  let n = 0;
+  forEachServiceRequest(bundle, () => { n++; });
+  return n;
+}

--- a/eRequest-placer-AI/modules/ai-decision-support.js
+++ b/eRequest-placer-AI/modules/ai-decision-support.js
@@ -41,11 +41,13 @@ const SYSTEM_PROMPT = [
   '      "dimension": "appropriateness | suggestion | duplicate | context",',
   '      "summary": "Brief plain-English summary, 1-2 sentences, for a clinician — no jargon, no alarm language",',
   '      "detail": "Optional longer explanation",',
-  '      "related_tests": ["<SNOMED concept id from the current request this relates to>"]',
+  '      "related_tests": ["<SNOMED concept id>"],',
+  '      "kind": "PATH | IMAG"',
   '    }',
   '  ]',
   '}',
-  'overall_severity is "serious" if any finding is serious, otherwise "advisory" if any findings exist, otherwise "none". findings may be an empty array. related_tests may be empty.',
+  'overall_severity is "serious" if any finding is serious, otherwise "advisory" if any findings exist, otherwise "none". findings may be an empty array.',
+  'For most findings related_tests holds SNOMED ids from the CURRENT request that the finding relates to (may be empty). For a "suggestion" finding, related_tests holds the SNOMED id(s) of the test(s) you are suggesting be ADDED, and "kind" is that test\'s category — "IMAG" for imaging/radiology or "PATH" for pathology/laboratory. Omit "kind" for non-suggestion findings.',
 ].join('\n');
 
 /**
@@ -136,6 +138,14 @@ export function validateDecisionResult(parsed) {
     } else {
       finding.related_tests = [];
     }
+    // Optional category for a suggested test (drives the "Add test" affordance so
+    // an imaging suggestion isn't silently added as pathology). Only kept when the
+    // model gives a recognisable value; left undefined otherwise.
+    // Lenient prefix match (as Feature B's normaliseKind): IMAG/IMAGING/RAD… ->
+    // IMAG; PATH/PATHOLOGY/LAB… -> PATH; anything else leaves kind undefined.
+    const k = String(f.kind || '').trim().toUpperCase();
+    if (k.startsWith('IMAG') || k.startsWith('RAD')) finding.kind = 'IMAG';
+    else if (k.startsWith('PATH') || k.startsWith('LAB')) finding.kind = 'PATH';
     findings.push(finding);
   }
 

--- a/eRequest-placer-AI/modules/ai-ui.js
+++ b/eRequest-placer-AI/modules/ai-ui.js
@@ -182,12 +182,212 @@ export function renderErrorState(container, message, onRetry) {
   container.appendChild(box);
 }
 
-// ----- Phase 4 (decision support) stubs — implemented in that phase. -----
-export function renderAdvisoryPanel(/* { container, findings, onAddTest, onDismiss } */) {
-  console.warn('ai-ui.renderAdvisoryPanel is a Phase 4 stub — not implemented yet.');
+// ----- Feature C: decision support (spec §C.9) -----
+
+const SEVERITY_STYLE = {
+  advisory: { row: 'border-amber-200 bg-amber-50', dot: 'bg-amber-500', label: 'Advisory' },
+  serious:  { row: 'border-red-300 bg-red-50',     dot: 'bg-red-600',   label: 'Review' },
+};
+
+// A SNOMED concept id is a bare integer string — only those get an "Add test"
+// affordance (we can't add a test we can't identify).
+function isSnomedId(s) { return /^[0-9]+$/.test(String(s || '')); }
+
+function severityBadge(severity) {
+  const style = SEVERITY_STYLE[severity] || SEVERITY_STYLE.advisory;
+  const wrap = document.createElement('span');
+  wrap.className = 'inline-flex items-center gap-1 text-[11px] font-medium';
+  const dot = document.createElement('span');
+  dot.className = 'inline-block w-2 h-2 rounded-full ' + style.dot;
+  dot.setAttribute('aria-hidden', 'true');
+  const txt = document.createElement('span');
+  txt.textContent = style.label;
+  wrap.appendChild(dot);
+  wrap.appendChild(txt);
+  return wrap;
 }
 
-export function openSeriousReviewModal(/* { findings, advisoryFindings } */) {
-  console.warn('ai-ui.openSeriousReviewModal is a Phase 4 stub — not implemented yet.');
-  return Promise.resolve({ action: 'proceed' });
+/**
+ * Tier 1 — inline, non-blocking advisory panel (spec §C.9). Renders every finding
+ * with its summary + severity indicator. `suggestion` findings whose related_tests
+ * contain a SNOMED id get one-click "Add test" buttons. All text via textContent.
+ *
+ * @param {object} o
+ * @param {HTMLElement} o.container
+ * @param {Array} o.findings              — validated findings (severity, dimension, summary, …)
+ * @param {(code:string)=>void} [o.onAddTest]
+ * @param {()=>void} [o.onDismiss]
+ */
+export function renderAdvisoryPanel({ container, findings, onAddTest, onDismiss }) {
+  if (!container) return;
+  container.replaceChildren();
+  const list = Array.isArray(findings) ? findings : [];
+  if (!list.length) { container.classList.add('hidden'); return; }
+  container.classList.remove('hidden');
+
+  const box = document.createElement('div');
+  box.className = 'border border-gray-200 rounded-lg p-3 bg-white';
+
+  const header = document.createElement('div');
+  header.className = 'flex items-center justify-between gap-2 mb-2';
+  const h = document.createElement('div');
+  h.className = 'text-sm font-semibold text-gray-700';
+  h.textContent = 'Decision support — ' + list.length + ' point' + (list.length === 1 ? '' : 's') + ' to consider';
+  header.appendChild(h);
+  const dismiss = document.createElement('button');
+  dismiss.type = 'button';
+  dismiss.className = 'text-xs px-2 py-1 rounded border bg-white hover:bg-gray-50';
+  dismiss.textContent = 'Dismiss';
+  dismiss.onclick = () => { container.classList.add('hidden'); if (typeof onDismiss === 'function') onDismiss(); };
+  header.appendChild(dismiss);
+  box.appendChild(header);
+
+  const ul = document.createElement('ul');
+  ul.setAttribute('role', 'list');
+  ul.className = 'space-y-2';
+  list.forEach((f) => {
+    const style = SEVERITY_STYLE[f.severity] || SEVERITY_STYLE.advisory;
+    const li = document.createElement('li');
+    li.className = 'border rounded-md p-2 ' + style.row;
+
+    const top = document.createElement('div');
+    top.className = 'flex items-start justify-between gap-2';
+    const summary = document.createElement('span');
+    summary.className = 'text-sm text-gray-800';
+    summary.textContent = f.summary || '';
+    top.appendChild(summary);
+    top.appendChild(severityBadge(f.severity));
+    li.appendChild(top);
+
+    // One-click "Add test" for suggestion findings with identifiable SNOMED codes.
+    if (f.dimension === 'suggestion' && typeof onAddTest === 'function' && Array.isArray(f.related_tests)) {
+      const codes = f.related_tests.filter(isSnomedId);
+      if (codes.length) {
+        const actions = document.createElement('div');
+        actions.className = 'flex flex-wrap gap-2 mt-1.5';
+        codes.forEach((code) => {
+          const add = document.createElement('button');
+          add.type = 'button';
+          add.className = 'text-xs px-2 py-1 rounded bg-indigo-600 text-white';
+          add.textContent = '+ Add test (' + code + ')';
+          add.onclick = () => { add.disabled = true; add.classList.add('btn-disabled'); onAddTest(code); };
+          actions.appendChild(add);
+        });
+        li.appendChild(actions);
+      }
+    }
+    ul.appendChild(li);
+  });
+  box.appendChild(ul);
+  container.appendChild(box);
+}
+
+/**
+ * Tier 2 — blocking serious-review modal (spec §C.9). Resolves with the string
+ * 'edit' (return to form) or 'proceed' (send as-is, acknowledgement recorded).
+ * Proceed stays disabled until the confirm checkbox is ticked. Keyboard
+ * accessible: focus trap, ESC resolves 'edit', focus returns to the send button.
+ *
+ * @param {object} o
+ * @param {Array} o.findings           — serious findings (summary + detail)
+ * @param {Array} [o.advisoryFindings] — advisory findings, shown for completeness
+ * @returns {Promise<'edit'|'proceed'>}
+ */
+export function openSeriousReviewModal({ findings, advisoryFindings } = {}) {
+  const backdrop = document.getElementById('ai-serious-backdrop');
+  const body = document.getElementById('ai-serious-body');
+  const confirm = document.getElementById('ai-serious-confirm');
+  const editBtn = document.getElementById('ai-serious-edit');
+  const proceedBtn = document.getElementById('ai-serious-proceed');
+  // If the markup is missing, fail safe to 'edit' (never silently send).
+  if (!backdrop || !body || !confirm || !editBtn || !proceedBtn) {
+    console.warn('ai-ui.openSeriousReviewModal: modal markup missing — defaulting to edit.');
+    return Promise.resolve('edit');
+  }
+
+  const serious = Array.isArray(findings) ? findings : [];
+  const advisory = Array.isArray(advisoryFindings) ? advisoryFindings : [];
+
+  // ----- populate -----
+  body.replaceChildren();
+  serious.forEach((f) => body.appendChild(findingBlock(f, 'serious')));
+  if (advisory.length) {
+    const sub = document.createElement('div');
+    sub.className = 'pt-2 mt-1 border-t';
+    const lbl = document.createElement('div');
+    lbl.className = 'text-xs font-medium text-gray-500 mb-1';
+    lbl.textContent = 'Also noted (no acknowledgement required)';
+    sub.appendChild(lbl);
+    advisory.forEach((f) => sub.appendChild(findingBlock(f, 'advisory')));
+    body.appendChild(sub);
+  }
+
+  // ----- reset controls -----
+  confirm.checked = false;
+  proceedBtn.disabled = true;
+  const previouslyFocused = document.activeElement;
+
+  return new Promise((resolve) => {
+    const focusables = () => Array.from(
+      backdrop.querySelectorAll('button, input, [href], [tabindex]:not([tabindex="-1"])')
+    ).filter((el) => !el.disabled && el.offsetParent !== null);
+
+    const onConfirmChange = () => { proceedBtn.disabled = !confirm.checked; };
+
+    const close = (result) => {
+      backdrop.style.display = 'none';
+      confirm.removeEventListener('change', onConfirmChange);
+      editBtn.removeEventListener('click', onEdit);
+      proceedBtn.removeEventListener('click', onProceed);
+      backdrop.removeEventListener('keydown', onKeydown);
+      // Return focus to the send button (spec §C.9 accessibility).
+      const sendBtn = document.getElementById('send-btn');
+      const target = sendBtn || previouslyFocused;
+      if (target && typeof target.focus === 'function') target.focus();
+      resolve(result);
+    };
+
+    const onEdit = () => close('edit');
+    const onProceed = () => { if (!proceedBtn.disabled) close('proceed'); };
+    function onKeydown(e) {
+      if (e.key === 'Escape') { e.preventDefault(); close('edit'); return; }
+      if (e.key !== 'Tab') return;
+      const els = focusables();
+      if (!els.length) return;
+      const first = els[0];
+      const last = els[els.length - 1];
+      if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+      else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+    }
+
+    confirm.addEventListener('change', onConfirmChange);
+    editBtn.addEventListener('click', onEdit);
+    proceedBtn.addEventListener('click', onProceed);
+    backdrop.addEventListener('keydown', onKeydown);
+
+    backdrop.style.display = 'flex';
+    // Initial focus inside the modal.
+    confirm.focus();
+  });
+}
+
+function findingBlock(f, severity) {
+  const style = SEVERITY_STYLE[severity] || SEVERITY_STYLE.serious;
+  const block = document.createElement('div');
+  block.className = 'border rounded-md p-2 mb-2 ' + style.row;
+  const top = document.createElement('div');
+  top.className = 'flex items-start justify-between gap-2';
+  const summary = document.createElement('span');
+  summary.className = 'text-sm font-medium text-gray-800';
+  summary.textContent = (f && f.summary) || '';
+  top.appendChild(summary);
+  top.appendChild(severityBadge(severity));
+  block.appendChild(top);
+  if (f && f.detail) {
+    const detail = document.createElement('p');
+    detail.className = 'text-sm text-gray-600 mt-1';
+    detail.textContent = f.detail;
+    block.appendChild(detail);
+  }
+  return block;
 }

--- a/eRequest-placer-AI/modules/ai-ui.js
+++ b/eRequest-placer-AI/modules/ai-ui.js
@@ -270,7 +270,8 @@ export function renderAdvisoryPanel({ container, findings, onAddTest, onDismiss 
           add.type = 'button';
           add.className = 'text-xs px-2 py-1 rounded bg-indigo-600 text-white';
           add.textContent = '+ Add test (' + code + ')';
-          add.onclick = () => { add.disabled = true; add.classList.add('btn-disabled'); onAddTest(code); };
+          // Pass the finding's category through so an imaging suggestion isn't added as pathology.
+          add.onclick = () => { add.disabled = true; add.classList.add('btn-disabled'); onAddTest(code, f.kind); };
           actions.appendChild(add);
         });
         li.appendChild(actions);

--- a/eRequest-placer-AI/modules/prior-requests.js
+++ b/eRequest-placer-AI/modules/prior-requests.js
@@ -1,0 +1,63 @@
+// modules/prior-requests.js — Feature C (decision support) prior-request context.
+//
+// Fetches a patient's recent ServiceRequests from the configured FHIR server so
+// the decision-support agent can spot duplicates (spec §C.5). Deliberately
+// best-effort: any failure, empty result, or missing patient id resolves to an
+// empty array and NEVER blocks the caller (spec §C.3, §C.5). FHIR auth is applied
+// automatically by the fetch monkey-patch in server.js — no extra work here.
+
+import { state } from './state.js';
+import { setDebugUrl } from './utils.js';
+
+const INCLUDE_STATUS = new Set(['active', 'completed', 'on-hold']);
+
+/**
+ * Fetch + summarise recent ServiceRequests for a patient.
+ * @param {string} patientId — server id of the patient (omit/empty -> []).
+ * @returns {Promise<Array<{code:string|null, display:string|null, system:string|null, authored:string|null}>>}
+ */
+export async function fetchAndSummarisePrior(patientId) {
+  const id = String(patientId || '').trim();
+  if (!id || !state.FHIR_BASE) return [];
+
+  try {
+    // Primary sort is -authored (spec §C.5). Some servers don't index `authored`
+    // for ServiceRequest search and answer 4xx; fall back to -_lastUpdated once.
+    let resp = await queryWith(id, '-authored');
+    if (resp && !resp.ok && resp.status >= 400 && resp.status < 500) {
+      resp = await queryWith(id, '-_lastUpdated');
+    }
+    if (!resp || !resp.ok) return [];
+
+    let bundle;
+    try { bundle = await resp.json(); } catch (_e) { return []; }
+
+    const entries = Array.isArray(bundle && bundle.entry) ? bundle.entry : [];
+    const out = [];
+    for (const e of entries) {
+      const res = e && e.resource;
+      if (!res || res.resourceType !== 'ServiceRequest') continue;
+      if (!INCLUDE_STATUS.has(res.status)) continue;
+      const coding = (res.code && Array.isArray(res.code.coding) && res.code.coding[0]) || null;
+      out.push({
+        code: coding ? (coding.code || null) : null,
+        display: (coding && coding.display) || (res.code && res.code.text) || null,
+        system: coding ? (coding.system || null) : null,
+        authored: res.authoredOn || null,
+      });
+    }
+    return out;
+  } catch (_e) {
+    // Network error / abort / anything else: degrade silently, never block.
+    return [];
+  }
+}
+
+function queryWith(patientId, sort) {
+  const url = new URL(state.FHIR_BASE.replace(/\/+$/, '') + '/ServiceRequest');
+  url.searchParams.set('subject', 'Patient/' + patientId);
+  url.searchParams.set('_sort', sort);
+  url.searchParams.set('_count', '20');
+  setDebugUrl(url.toString());
+  return fetch(url.toString(), { headers: { Accept: 'application/fhir+json' } });
+}


### PR DESCRIPTION
﻿## What

Implements **Feature C — AI-enhanced decision support** (Phase 4, spec §C). At Send, after the FHIR bundle is built and before the POST, the request is evaluated across four dimensions (appropriateness / suggestions / duplicates / context). Results drive a two-tier UI: a non-blocking **Tier 1 advisory panel**, and for serious findings a blocking **Tier 2 review modal** that records an acknowledgement on the bundle when the clinician proceeds.

## Changes

**New**
- `modules/prior-requests.js` — `fetchAndSummarisePrior(patientId)`: recent `ServiceRequest`s for duplicate context (§C.5). Best-effort — 4xx on `-authored` retries once with `-_lastUpdated`; any failure / empty / missing id returns `[]` and never blocks. Logged to the debug panel; FHIR auth applied by the existing monkey-patch.
- `modules/ai-decision-support.js` — `shouldRunDecisionSupport` (gating §C.3), `evaluateRequest` (§C.6 context incl. prior requests, §C.7 prompt with operator guidelines), `validateDecisionResult` (pure §C.8 normaliser: drops malformed findings, recomputes `overall_severity`), `appendAcknowledgementNote` (§C.10).

**Modified**
- `modules/ai-ui.js` — real `renderAdvisoryPanel` (Tier 1; one-click "Add test" for `suggestion` findings carrying a SNOMED id) and `openSeriousReviewModal` (Tier 2; checkbox-gated Proceed, focus trap, ESC, focus returned to Send), replacing the Phase 1 stubs. Resolves the string `'edit'`/`'proceed'`.
- `app.js` — `preSendHook` wired into `initSendButton` implementing the §C.3/§C.9 flow; `onAddTest` does a `lookupConcept` then `addSelectedTest`.
- `index.html` — `#ai-advisory-panel` (above Selected Tests) + `#ai-serious-backdrop` modal.

**Not changed (already in place):** `server.js` already supported `preSendHook`; the decision-support toggle + guidelines field already shipped in `settings-ai.js`.

## Design notes

- Guidelines reach the prompt via `combineGuidance(COMMON_PROMPT_SUPPLEMENTS, GUIDELINES_SUMMARY)`, so common guidance applies to Feature C too; empty summary still works (runs on general clinical training).
- `validateDecisionResult` recomputes `overall_severity` from surviving findings rather than trusting the model's field.
- **Scope boundary:** decision support sees only prior `ServiceRequest`s. Richer history-backed rules (Observations / Conditions / meds via an **agent FHIR-query tool**) are split out to #25 per discussion — no MCP needed, reuses the existing authed fetch.
- `onAddTest` defaults added tests to `PATH` (kind isn't recoverable from a bare SNOMED id).

## Acceptance criteria (§C.13)

- [x] Phases 2 (#15) and 3 (#16) merged
- [x] §C.13.1 — triggers on Send with >=1 test + clinical notes (`shouldRunDecisionSupport`)
- [x] §C.13.2 — full §C.6 context incl. prior requests
- [x] §C.13.3 — guidelines summary injected into the system prompt
- [x] §C.13.4 — advisory findings in non-blocking Tier 1 panel
- [x] §C.13.5 — serious findings replace Send with the Tier 2 modal
- [x] §C.13.6 — modal requires checkbox acknowledgement before Proceed
- [x] §C.13.7 — acknowledgement recorded in `ServiceRequest.note`
- [x] §C.13.8 — unavailable -> brief notice, send proceeds
- [x] §C.13.9 — prior query conforms + appears in debug panel
- [x] §C.13.10 — disableable via settings (toggle already present)
- [x] Modal keyboard-accessible (focus trap, ESC, focus returns to Send)

## Verification

- `node --check` on all changed modules.
- Targeted Node tests (10 assertions, stubbed `fetch`/`document`/`localStorage`): `validateDecisionResult` normalisation + `overall_severity` derivation; `appendAcknowledgementNote` appends-not-replaces on every SR only; `shouldRunDecisionSupport` gating matrix; `prior-requests` filter/summarise + `-authored`->`-_lastUpdated` retry + network-error degradation. (Throwaway — no committed suite exists in the repo.)
- Headless Edge boot: new elements render and `boot()` completes without error (JS-injected settings panel + pregnancy options present).

**Live keyed end-to-end** (§C.13 scenarios 1-8 — agent round-trip, advisory-only vs serious, ack note in posted bundle, toggle-off bypass, no-key "unavailable") is for @MattCordell, as usual.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)
