### PR TITLE
feat(eRequest-placer-AI): debug-only AI prompt log

### DIFF
--- a/eRequest-placer-AI/index.html
+++ b/eRequest-placer-AI/index.html
@@ -477,18 +477,23 @@
   <div id="debug-panel" class="fixed bottom-16 right-4 z-40 w-[min(90vw,42rem)] max-h-[50vh] overflow-hidden hidden">
     <div class="bg-yellow-100 border border-yellow-300 rounded shadow">
       <div class="flex items-center justify-between px-3 py-2 border-b border-yellow-300">
-        <div class="font-semibold text-yellow-900 text-sm">Terminology/FHIR calls — recent</div>
+        <div class="font-semibold text-yellow-900 text-sm">Debug — recent calls &amp; AI prompts</div>
         <div class="flex items-center gap-2">
           <button id="debug-copy" class="text-xs px-2 py-1 rounded border border-yellow-400 bg-white">Copy last</button>
           <button id="debug-close" class="text-xs px-2 py-1 rounded border border-yellow-400 bg-white">Close</button>
         </div>
       </div>
-      <div class="p-3">
+      <div class="p-3 overflow-auto max-h-[44vh]">
         <div id="ai-backend-banner" class="text-[11px] text-yellow-900 mb-2 font-medium bg-yellow-50 border border-yellow-200 rounded p-2">AI: initialising…</div>
         <div class="text-xs text-yellow-900 mb-1">Most recent URL:</div>
         <div id="last-expand-url" class="text-[11px] break-all bg-yellow-50 border border-yellow-200 rounded p-2"></div>
-        <div class="text-xs text-yellow-900 mt-3 mb-1">History (most recent first):</div>
-        <ul id="expand-history" class="text-[11px] space-y-1 max-h-[22vh] overflow-auto pr-1"></ul>
+        <div class="text-xs text-yellow-900 mt-3 mb-1">Terminology/FHIR calls (most recent first):</div>
+        <ul id="expand-history" class="text-[11px] space-y-1 max-h-[16vh] overflow-auto pr-1"></ul>
+        <div class="text-xs text-yellow-900 mt-3 mb-1 flex items-center justify-between gap-2">
+          <span>AI prompts sent to the model (most recent first):</span>
+          <button id="ai-prompt-copy" class="text-[11px] px-2 py-0.5 rounded border border-yellow-400 bg-white">Copy all</button>
+        </div>
+        <ul id="ai-prompt-log" class="text-[11px] space-y-1 max-h-[22vh] overflow-auto pr-1"></ul>
       </div>
     </div>
   </div>

--- a/eRequest-placer-AI/modules/openrouter-client.js
+++ b/eRequest-placer-AI/modules/openrouter-client.js
@@ -9,7 +9,7 @@
 //                 Authorization: Bearer <userKey>
 
 import { getAiSettings } from './settings-ai.js';
-import { setDebugUrl } from './utils.js';
+import { setDebugUrl, logAiPrompt } from './utils.js';
 
 /**
  * Thrown for any non-success outcome. `kind` lets callers branch:
@@ -84,6 +84,17 @@ export async function chatCompletion({ model, messages, tools, signal } = {}) {
     payload.tool_choice = 'auto';
   }
   const body = JSON.stringify(payload);
+
+  // Debug-only: record the exact payload sent to the model so it can be inspected
+  // from the Debug panel. Once per call (not per retry). Never throws.
+  try {
+    logAiPrompt({
+      model: payload.model,
+      route: useOwnKey ? 'own-key' : 'proxy',
+      messages,
+      toolCount: Array.isArray(tools) ? tools.length : 0,
+    });
+  } catch (_e) { /* logging must never break a request */ }
 
   // One retry on 429/5xx with a fixed backoff; no retry on other statuses.
   let attempt = 0;

--- a/eRequest-placer-AI/modules/utils.js
+++ b/eRequest-placer-AI/modules/utils.js
@@ -71,11 +71,84 @@ export function setDebugUrl(url) {
   });
 }
 
+// ----- AI prompt log (debug-only) -----
+// Captures the exact message payloads sent to the model so they can be inspected
+// from the Debug panel. This is a developer aid only — it is NOT shown in the
+// normal app UI. Prompts include clinical free-text / patient demographics, the
+// same data already visible in the terminology URLs above; same client-side,
+// same-origin risk posture (spec §9). Capture happens once per chatCompletion
+// call in openrouter-client.js.
+const aiPromptLog = { history: [], max: 20 };
+
+export function logAiPrompt(entry) {
+  if (!entry) return;
+  aiPromptLog.history.unshift({
+    ts: new Date(),
+    model: entry.model || '(default)',
+    route: entry.route || '',
+    messages: Array.isArray(entry.messages) ? entry.messages : [],
+    toolCount: entry.toolCount || 0,
+  });
+  if (aiPromptLog.history.length > aiPromptLog.max) aiPromptLog.history.pop();
+  renderAiPromptLog();
+}
+
+/** Snapshot of the captured prompts (most recent first), for the Copy-all button. */
+export function getAiPromptLog() {
+  return aiPromptLog.history.map((r) => ({
+    ts: r.ts.toISOString(), model: r.model, route: r.route, toolCount: r.toolCount, messages: r.messages,
+  }));
+}
+
+function formatMessages(messages) {
+  return messages.map((m) => {
+    const role = String(m.role || '?').toUpperCase();
+    let body;
+    if (typeof m.content === 'string') body = m.content;
+    else if (m.content == null) body = '';
+    else body = JSON.stringify(m.content);
+    let extra = '';
+    if (Array.isArray(m.tool_calls) && m.tool_calls.length) {
+      extra += '\n[tool_calls] ' + m.tool_calls
+        .map((tc) => ((tc.function && tc.function.name) || '?') + '(' + ((tc.function && tc.function.arguments) || '') + ')')
+        .join(', ');
+    }
+    if (m.tool_call_id) extra += '\n[tool_call_id] ' + m.tool_call_id;
+    return '── ' + role + ' ──\n' + body + extra;
+  }).join('\n\n');
+}
+
+function renderAiPromptLog() {
+  const ul = document.querySelector('#ai-prompt-log');
+  if (!ul) return;
+  ul.replaceChildren();
+  aiPromptLog.history.forEach((rec) => {
+    const li = document.createElement('li');
+    const det = document.createElement('details');
+    det.className = 'border border-yellow-200 rounded bg-yellow-50';
+    const sum = document.createElement('summary');
+    sum.className = 'cursor-pointer px-2 py-1 text-[11px] text-yellow-900';
+    sum.textContent = '[' + rec.ts.toLocaleTimeString() + '] '
+      + (rec.route ? rec.route + ' · ' : '') + rec.model
+      + ' · ' + rec.messages.length + ' msg'
+      + (rec.toolCount ? ' · ' + rec.toolCount + ' tools' : '');
+    det.appendChild(sum);
+    const pre = document.createElement('pre');
+    // textContent only — content carries AI-sourced / clinical free-text.
+    pre.className = 'text-[11px] whitespace-pre-wrap break-words p-2 border-t border-yellow-200 max-h-[30vh] overflow-auto';
+    pre.textContent = formatMessages(rec.messages);
+    det.appendChild(pre);
+    li.appendChild(det);
+    ul.appendChild(li);
+  });
+}
+
 export function initDebugPanel() {
   const panel = document.getElementById('debug-panel');
   const toggle = document.getElementById('debug-toggle');
   const close = document.getElementById('debug-close');
   const copy = document.getElementById('debug-copy');
+  const copyPrompts = document.getElementById('ai-prompt-copy');
 
   if (toggle) toggle.addEventListener('click', () => panel.classList.toggle('hidden'));
   if (close) close.addEventListener('click', () => panel.classList.add('hidden'));
@@ -87,6 +160,16 @@ export function initDebugPanel() {
       const old = copy.textContent;
       copy.textContent = 'Copied!';
       setTimeout(() => { copy.textContent = old; }, 1200);
+    } catch (_e) { /* clipboard blocked */ }
+  });
+  if (copyPrompts) copyPrompts.addEventListener('click', async () => {
+    const data = getAiPromptLog();
+    if (!data.length) return;
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(data, null, 2));
+      const old = copyPrompts.textContent;
+      copyPrompts.textContent = 'Copied!';
+      setTimeout(() => { copyPrompts.textContent = old; }, 1200);
     } catch (_e) { /* clipboard blocked */ }
   });
 }

--- a/eRequest-placer-AI/modules/utils.js
+++ b/eRequest-placer-AI/modules/utils.js
@@ -82,11 +82,20 @@ const aiPromptLog = { history: [], max: 20 };
 
 export function logAiPrompt(entry) {
   if (!entry) return;
+  // Snapshot the messages at capture time. runAgent reuses ONE messages array and
+  // mutates it across tool-loop iterations, so holding the live reference would
+  // make every entry for a run show the final transcript, not the per-call
+  // payload. Deep-clone (payloads are JSON-serialisable — they're JSON.stringify'd
+  // to send anyway); fall back to a shallow copy if cloning ever fails.
+  let messages = [];
+  try { messages = JSON.parse(JSON.stringify(entry.messages || [])); }
+  catch (_e) { messages = Array.isArray(entry.messages) ? entry.messages.slice() : []; }
+
   aiPromptLog.history.unshift({
     ts: new Date(),
     model: entry.model || '(default)',
     route: entry.route || '',
-    messages: Array.isArray(entry.messages) ? entry.messages : [],
+    messages,
     toolCount: entry.toolCount || 0,
   });
   if (aiPromptLog.history.length > aiPromptLog.max) aiPromptLog.history.pop();


### PR DESCRIPTION
﻿## What

Adds a **debug-only AI prompt log** so the exact message payloads sent to the model can be inspected — visible only via the **Debug** button, not in the normal app UI (as requested).

## How

- **Single capture point:** `openrouter-client.chatCompletion` logs once per call (not per retry). Every AI call — Features A (reason coding), B (test selection), C (decision support), and the `?aitest=1` harness — funnels through here, so there's no per-feature wiring. The log call is wrapped in try/catch so it can never break a request.
- **`utils.js`:** `logAiPrompt()` buffers the last 20 calls; `renderAiPromptLog()` draws them into the panel; `getAiPromptLog()` backs the Copy button. Each entry is a collapsible `<details>` row — `[time] route · model · N msg · tools` — whose body is the full system/user/tool transcript. Rendered with **`textContent`** throughout (content carries AI-sourced / clinical free-text).
- **`index.html`:** new "AI prompts sent to the model" section in the debug panel with a **Copy all** button (copies the buffer as JSON); panel body is now scrollable so it fits alongside the existing call list.

## Notes

- Prompts include clinical notes + patient demographics (age/sex/pregnancy) and, for Feature C, the prior-request summary. This is the **same data already visible in the terminology URLs** in this panel — same client-side, same-origin posture (spec §9). It's a developer aid; nothing is sent anywhere new.
- Buffer is in-memory only (last 20 calls), cleared on reload.

## Verify

- `node --check` on changed modules.
- DOM-stub unit test: buffering, 20-entry cap (newest first), snapshot shape, and the render path including `tool_calls` / `tool_call_id` formatting.
- Headless Edge boot: `#ai-prompt-log` + `#ai-prompt-copy` render and boot completes clean.
- **For you:** open Debug, run any AI feature, expand an entry to confirm the live prompt reads as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
