### PR TITLE
feat(eRequest-placer-AI): agent FHIR-query tool for history-backed decision support (#25)

### DIFF
--- a/eRequest-placer-AI/README.md
+++ b/eRequest-placer-AI/README.md
@@ -116,6 +116,27 @@ If *any* reason tag is a subtype of a parent code, all tests in that rule are su
 
 Edit **`clinicians.js`**. Add entries to `practitionerResources`, `roleSpecialties`, and `userFavourites`, then add a matching `<option>` in the doctor-select dropdown in `index.html`.
 
+## Decision support: agent patient-history tool
+
+Feature C (decision support) gives the agent a read-only `query_patient_history` tool
+(`modules/patient-history-tool.js`) so history-dependent rules are actionable — e.g.
+"don't repeat a test resulted recently" (Observation / DiagnosticReport), "flag a test
+with no documented indication" (Condition), or "avoid this test on medication X"
+(MedicationRequest). The agent decides what to pull per rule; the app no longer has to
+pre-fetch a fixed set.
+
+It is a thin local function (no MCP server) reusing the existing authed `fetch`, with
+guardrails enforced in the impl regardless of what the model asks:
+
+- **read-only** — GET only;
+- **allow-list** — `Observation`, `Condition`, `MedicationRequest`, `DiagnosticReport`, `ServiceRequest`;
+- **patient-scoped** — every query is forced to `subject=Patient/{id}`; the model cannot widen it;
+- **`_count` capped** and a **per-evaluation query budget** to bound latency / cost;
+- offered only when the patient is server-resolved; every query is logged to the debug panel.
+
+To adjust the limits, edit the constants (`ALLOWED_TYPES`, `MAX_COUNT`, `QUERY_BUDGET`) at the
+top of `modules/patient-history-tool.js`.
+
 ## What's next
 
 This directory is the scaffold for the AI-enhanced sister of `eRequest-placer`. Phase 1+ work introduces:

--- a/eRequest-placer-AI/README.md
+++ b/eRequest-placer-AI/README.md
@@ -137,6 +137,12 @@ guardrails enforced in the impl regardless of what the model asks:
 To adjust the limits, edit the constants (`ALLOWED_TYPES`, `MAX_COUNT`, `QUERY_BUDGET`) at the
 top of `modules/patient-history-tool.js`.
 
+> **Data egress note.** Enabling decision support sends clinical context to the LLM. This tool
+> expands that to the patient's actual lab values, diagnoses, medications, and reports
+> (summarised, with no name/MRN). On the default proxy route with a free-tier model that data
+> reaches a provider that may log it. For real patient data, use the "Use my own OpenRouter key"
+> route with a paid/non-logging model. See spec §9.
+
 ## What's next
 
 This directory is the scaffold for the AI-enhanced sister of `eRequest-placer`. Phase 1+ work introduces:

--- a/eRequest-placer-AI/ai-erequesting-spec.md
+++ b/eRequest-placer-AI/ai-erequesting-spec.md
@@ -271,6 +271,7 @@ The developer should treat the original app's FHIR interactions as the reference
 
 - All AI calls are non-blocking. The form must remain interactive during processing.
 - No clinical notes or patient data are logged or stored beyond what already occurs in the existing app.
+- **PHI egress to the LLM (decision support).** Feature C sends clinical context to the model. With the `query_patient_history` tool (issue #25) this expands beyond the clinician's notes and prior-request *codes* to the patient's actual **lab values (Observation), diagnoses (Condition), medications (MedicationRequest), and reports (DiagnosticReport)** — gated behind the decision-support toggle and offered only when a patient is resolved. Summaries omit direct identifiers (no name/MRN), but results, diagnoses, and meds are sensitive. On the default proxy route with a free-tier model, that data flows through the deployer's key to a provider that may log/retain it. **Adopters handling real patient data should use the own-key route with a paid/non-logging model (or self-hosted inference) for decision support**, and treat this as the same demo/reference risk posture as the API key and FHIR tokens (§9.1).
 - The Openrouter API key is stored client-side. This is consistent with the existing FHIR server auth model. The risk should be documented in a code comment.
 - Both AI features degrade gracefully if Openrouter or Ontoserver MCP is unavailable.
 - The shared AI module (Section 3) must be testable independently of the UI.

--- a/eRequest-placer-AI/ai-erequesting-spec.md
+++ b/eRequest-placer-AI/ai-erequesting-spec.md
@@ -505,14 +505,16 @@ Add the following to the settings panel (extending Section 6 of the main spec):
 
 ## C.12 FHIR Compliance Notes
 
-Decision support introduces one new FHIR interaction: a read query for prior ServiceRequests. This must:
+Decision support introduces new **read-only** FHIR interactions: a query for prior ServiceRequests (C.5), and — once the patient is resolved — agent-initiated history queries via the `query_patient_history` tool (issue #25). These must:
 
 - Use the FHIR server configured in the existing settings panel.
-- Conform to the AU eRequesting FHIR profile and any relevant AU Base profiles for ServiceRequest search.
+- Conform to the AU eRequesting FHIR profile and any relevant AU Base profiles for the resource being searched.
 - Respect any auth configuration already in place for the FHIR server connection.
 - Appear in the existing terminology/FHIR call debug log (the "recent calls" panel already present in the app).
 
-No new FHIR resource types are written or modified beyond the existing bundle submission, except the optional note appended per C.10.
+Agent-initiated history queries are read-only (GET), restricted to an allow-list of resource types (`Observation`, `Condition`, `MedicationRequest`, `DiagnosticReport`, `ServiceRequest`), always scoped to the current `subject=Patient/{id}`, `_count`-capped, and subject to a per-evaluation query budget.
+
+No FHIR resources are written or modified beyond the existing bundle submission, except the optional note appended per C.10.
 
 ---
 

--- a/eRequest-placer-AI/modules/ai-decision-support.js
+++ b/eRequest-placer-AI/modules/ai-decision-support.js
@@ -12,6 +12,7 @@ import { runAgent } from './ai-agent.js';
 import { getTools, searchConcepts, lookupConcept } from './ontoserver-tools.js';
 import { gatherPatientContext, combineGuidance } from './ai-context.js';
 import { fetchAndSummarisePrior } from './prior-requests.js';
+import { getHistoryTools, makeHistoryToolImpl } from './patient-history-tool.js';
 
 const VALID_SEVERITY = new Set(['advisory', 'serious']);
 const VALID_DIMENSION = new Set(['appropriateness', 'suggestion', 'duplicate', 'context']);
@@ -31,6 +32,7 @@ const SYSTEM_PROMPT = [
   '- "serious" — warrants clinician review before sending; one or more of: the test is clinically inappropriate for the patient\'s demographics; the combination of tests or implied diagnoses carries potential clinical risk; critical context is missing that would affect how the request is actioned; a high-risk test has been ordered without documented clinical justification.',
   '',
   'You have an Ontoserver tool (search_concepts / lookup_concept) available to validate a SNOMED concept if useful; using it is optional.',
+  'When a patient is identified you also have a query_patient_history tool: a read-only window onto THIS patient\'s FHIR record (Observation, Condition, MedicationRequest, DiagnosticReport, ServiceRequest), beyond the prior_requests already provided. Use it ONLY when a rule you are applying needs history not already in the context — e.g. to check whether a test was resulted recently, whether a documented indication (Condition) exists, or whether a relevant medication is active. It is patient-scoped and budget-limited, so be selective; if it is not offered or a query fails, reason from the context you do have.',
   '',
   'Return a JSON object ONLY (no prose, no markdown) in exactly this shape:',
   '{',
@@ -93,12 +95,24 @@ export async function evaluateRequest(bundle) {
       lookup_concept: (args) => lookupConcept(args),
     };
 
+    // History tool only when the patient is server-resolved (same condition as
+    // prior_requests above). The impl closes over `pid` so the agent can never
+    // query another patient, and over a per-evaluation query budget.
+    const tools = getTools();
+    if (pid) {
+      tools.push(...getHistoryTools());
+      toolImpl.query_patient_history = makeHistoryToolImpl({ patientId: pid });
+    }
+
     const { parsed, error } = await runAgent({
       systemPrompt,
       userMessage,
-      tools: getTools(),
+      tools,
       toolImpl,
       model: s.OPENROUTER_MODEL,
+      // History-querying adds round-trips on top of terminology validation;
+      // give the loop a little more headroom than the 8-iteration default.
+      maxIterations: 12,
     });
 
     if (error) return { result: null, error };

--- a/eRequest-placer-AI/modules/patient-history-tool.js
+++ b/eRequest-placer-AI/modules/patient-history-tool.js
@@ -1,0 +1,250 @@
+// modules/patient-history-tool.js — Feature C: agent-initiated patient-history query tool.
+//
+// Gives the decision-support agent a read-only window onto the patient's FHIR
+// record beyond the pre-fetched prior ServiceRequests (issue #25). The agent
+// decides, per rule, what to pull (e.g. "don't repeat HbA1c resulted in the last
+// 3 months" -> recent Observations / DiagnosticReports). Deliberately a thin
+// local function rather than an MCP server: it reuses the existing authed
+// fetch monkey-patch (server.js) and works in headless/automated contexts where
+// interactively-authed MCP servers may be absent.
+//
+// Guardrails (all enforced HERE, ignoring anything the model claims):
+//   - read-only (GET only)
+//   - resourceType allow-list
+//   - every query scoped to subject=Patient/{id} — the model cannot widen it
+//   - _count capped
+//   - a per-evaluation query budget (the factory closes over a call counter)
+// Every query is logged via setDebugUrl so it shows in the debug panel (spec §C.12).
+
+import { state } from './state.js';
+import { setDebugUrl } from './utils.js';
+
+// Resource types the agent may read. Chosen for the history-dependent rules in
+// issue #25 (Observations/DiagnosticReports for recent results, Conditions for
+// documented indications, MedicationRequests for drug interactions) plus
+// ServiceRequest so the agent can filter prior orders by code/date itself.
+const ALLOWED_TYPES = new Set([
+  'Observation', 'Condition', 'MedicationRequest', 'DiagnosticReport', 'ServiceRequest',
+]);
+
+// Hard cap on _count regardless of what the model asks for.
+const MAX_COUNT = 20;
+
+// Per-evaluation ceiling on the number of history queries the agent may make.
+// Bounds prompt size / latency / cost of agent-initiated fetching (issue #25).
+const QUERY_BUDGET = 6;
+
+// Per-resource clinical date search parameter for the optional `dateFrom` filter.
+// Falls back to the universal `_lastUpdated` if the server rejects the clinical
+// param (mirrors the prior-requests -authored -> -_lastUpdated fallback).
+const DATE_PARAM = {
+  Observation: 'date',
+  DiagnosticReport: 'date',
+  Condition: 'recorded-date',
+  MedicationRequest: 'authoredon',
+  ServiceRequest: 'authored',
+};
+
+/** OpenAI-format tool descriptor advertised to the model (Feature C only). */
+export function getHistoryTools() {
+  return [
+    {
+      type: 'function',
+      function: {
+        name: 'query_patient_history',
+        description: 'Read the current patient\'s FHIR history to evaluate a history-dependent rule '
+          + '(e.g. avoid repeating a test resulted recently, check for a documented indication, or a '
+          + 'relevant medication). Read-only and automatically scoped to THIS patient — you cannot query '
+          + 'another patient. Returns a compact summarised list, not raw FHIR. Use it only when a rule you '
+          + 'are applying needs data not already in the provided context; there is a small per-evaluation '
+          + 'query budget, so be selective.',
+        parameters: {
+          type: 'object',
+          properties: {
+            resourceType: {
+              type: 'string',
+              enum: Array.from(ALLOWED_TYPES),
+              description: 'FHIR resource type to read.',
+            },
+            code: {
+              type: 'string',
+              description: 'Optional code token to filter to a specific test/finding/medication, '
+                + 'e.g. "http://snomed.info/sct|43396009" or a bare code.',
+            },
+            category: {
+              type: 'string',
+              description: 'Optional category token, e.g. "laboratory" for Observations.',
+            },
+            dateFrom: {
+              type: 'string',
+              description: 'Optional ISO date (YYYY-MM-DD); returns only records on/after this date.',
+            },
+            count: {
+              type: 'integer',
+              description: 'Max results (default ' + MAX_COUNT + ', hard cap ' + MAX_COUNT + ').',
+            },
+          },
+          required: ['resourceType'],
+        },
+      },
+    },
+  ];
+}
+
+/**
+ * Build the toolImpl for query_patient_history, scoped to one patient for the
+ * duration of one decision-support evaluation. The returned function closes over
+ * a private call counter implementing the per-evaluation query budget.
+ * @param {object} opts
+ * @param {string} opts.patientId — server id of the current patient.
+ * @returns {(args:object) => Promise<object>}
+ */
+export function makeHistoryToolImpl({ patientId } = {}) {
+  const id = String(patientId || '').trim();
+  let used = 0;
+
+  return async function queryPatientHistory(args) {
+    args = args || {};
+
+    if (!id) return { error: 'No patient resolved; patient history is unavailable.' };
+    if (!state.FHIR_BASE) return { error: 'No FHIR server configured.' };
+
+    const resourceType = String(args.resourceType || '').trim();
+    if (!ALLOWED_TYPES.has(resourceType)) {
+      return { error: 'resourceType not allowed. Allowed types: ' + Array.from(ALLOWED_TYPES).join(', ') + '.' };
+    }
+
+    if (used >= QUERY_BUDGET) {
+      return { error: 'Patient-history query budget exhausted (max ' + QUERY_BUDGET + ' per evaluation).' };
+    }
+    used++;
+
+    try {
+      // Primary attempt uses the per-resource clinical date param; on a 4xx
+      // (param unsupported/unindexed) retry once with the universal _lastUpdated.
+      let resp = await runQuery(resourceType, id, args, false);
+      if (resp && !resp.ok && resp.status >= 400 && resp.status < 500 && args.dateFrom) {
+        resp = await runQuery(resourceType, id, args, true);
+      }
+      if (!resp || !resp.ok) {
+        return { error: 'FHIR query failed (status ' + (resp ? resp.status : 'network') + ').' };
+      }
+
+      let bundle;
+      try { bundle = await resp.json(); } catch (_e) { return { error: 'Could not parse FHIR response.' }; }
+
+      const entries = Array.isArray(bundle && bundle.entry) ? bundle.entry : [];
+      const records = [];
+      for (const e of entries) {
+        const res = e && e.resource;
+        if (!res || res.resourceType !== resourceType) continue;
+        records.push(summarise(resourceType, res));
+      }
+      return { resourceType, count: records.length, records };
+    } catch (e) {
+      if (e && e.name === 'AbortError') throw e;
+      return { error: String((e && e.message) || e) };
+    }
+  };
+}
+
+// ----- query construction -----
+
+function runQuery(resourceType, patientId, args, useLastUpdated) {
+  const url = new URL(state.FHIR_BASE.replace(/\/+$/, '') + '/' + resourceType);
+  // Patient scope is fixed here — never taken from model args.
+  url.searchParams.set('subject', 'Patient/' + patientId);
+
+  if (args.code) url.searchParams.set('code', String(args.code));
+  if (args.category) url.searchParams.set('category', String(args.category));
+
+  if (args.dateFrom) {
+    const param = useLastUpdated ? '_lastUpdated' : (DATE_PARAM[resourceType] || '_lastUpdated');
+    url.searchParams.set(param, 'ge' + String(args.dateFrom));
+  }
+
+  url.searchParams.set('_count', String(clampCount(args.count)));
+  setDebugUrl(url.toString());
+  return fetch(url.toString(), { headers: { Accept: 'application/fhir+json' } });
+}
+
+function clampCount(n) {
+  const v = parseInt(n, 10);
+  if (!Number.isFinite(v) || v <= 0) return MAX_COUNT;
+  return Math.min(v, MAX_COUNT);
+}
+
+// ----- summarisers (compact, to limit prompt size / cost) -----
+
+function firstCoding(cc) {
+  return (cc && Array.isArray(cc.coding) && cc.coding[0]) || null;
+}
+
+function codeDisplay(cc) {
+  const c = firstCoding(cc);
+  return {
+    code: c ? (c.code || null) : null,
+    display: (c && c.display) || (cc && cc.text) || null,
+  };
+}
+
+function summarise(resourceType, res) {
+  switch (resourceType) {
+    case 'Observation': return summariseObservation(res);
+    case 'DiagnosticReport': return summariseDiagnosticReport(res);
+    case 'Condition': return summariseCondition(res);
+    case 'MedicationRequest': return summariseMedicationRequest(res);
+    case 'ServiceRequest': return summariseServiceRequest(res);
+    default: return { code: null, display: null };
+  }
+}
+
+function summariseObservation(res) {
+  const cd = codeDisplay(res.code);
+  let value = null;
+  if (res.valueQuantity) {
+    value = { value: res.valueQuantity.value, unit: res.valueQuantity.unit || res.valueQuantity.code || null };
+  } else if (res.valueCodeableConcept) {
+    value = codeDisplay(res.valueCodeableConcept).display;
+  } else if (res.valueString != null) {
+    value = String(res.valueString);
+  }
+  return {
+    code: cd.code, display: cd.display, value, status: res.status || null,
+    effective: res.effectiveDateTime || (res.effectivePeriod && res.effectivePeriod.start) || null,
+  };
+}
+
+function summariseDiagnosticReport(res) {
+  const cd = codeDisplay(res.code);
+  return {
+    code: cd.code, display: cd.display, status: res.status || null,
+    effective: res.effectiveDateTime || (res.effectivePeriod && res.effectivePeriod.start) || null,
+  };
+}
+
+function summariseCondition(res) {
+  const cd = codeDisplay(res.code);
+  const cs = firstCoding(res.clinicalStatus);
+  return {
+    code: cd.code, display: cd.display,
+    clinicalStatus: cs ? (cs.code || null) : null,
+    onset: res.onsetDateTime || res.recordedDate || null,
+  };
+}
+
+function summariseMedicationRequest(res) {
+  let medication = null;
+  if (res.medicationCodeableConcept) medication = codeDisplay(res.medicationCodeableConcept).display;
+  else if (res.medicationReference) medication = res.medicationReference.display || null;
+  return {
+    medication, status: res.status || null, authoredOn: res.authoredOn || null,
+  };
+}
+
+function summariseServiceRequest(res) {
+  const cd = codeDisplay(res.code);
+  return {
+    code: cd.code, display: cd.display, status: res.status || null, authoredOn: res.authoredOn || null,
+  };
+}

--- a/eRequest-placer-AI/modules/patient-history-tool.js
+++ b/eRequest-placer-AI/modules/patient-history-tool.js
@@ -201,18 +201,32 @@ function summarise(resourceType, res) {
 
 function summariseObservation(res) {
   const cd = codeDisplay(res.code);
-  let value = null;
-  if (res.valueQuantity) {
-    value = { value: res.valueQuantity.value, unit: res.valueQuantity.unit || res.valueQuantity.code || null };
-  } else if (res.valueCodeableConcept) {
-    value = codeDisplay(res.valueCodeableConcept).display;
-  } else if (res.valueString != null) {
-    value = String(res.valueString);
-  }
   return {
-    code: cd.code, display: cd.display, value, status: res.status || null,
+    code: cd.code, display: cd.display, value: observationValue(res), status: res.status || null,
     effective: res.effectiveDateTime || (res.effectivePeriod && res.effectivePeriod.start) || null,
   };
+}
+
+// Observation.value[x] — cover the common types. A null value can mislead a
+// history-dependent rule into thinking a result is missing (e.g. a boolean
+// positive/negative or an integer count), so handle boolean/integer/ratio too,
+// not just quantity/codeable/string. `!= null` keeps falsy-but-present values
+// (false, 0).
+function observationValue(res) {
+  if (res.valueQuantity) {
+    return { value: res.valueQuantity.value, unit: res.valueQuantity.unit || res.valueQuantity.code || null };
+  }
+  if (res.valueCodeableConcept) return codeDisplay(res.valueCodeableConcept).display;
+  if (res.valueString != null) return String(res.valueString);
+  if (res.valueBoolean != null) return res.valueBoolean;
+  if (res.valueInteger != null) return res.valueInteger;
+  if (res.valueRatio) {
+    const num = res.valueRatio.numerator && res.valueRatio.numerator.value;
+    const den = res.valueRatio.denominator && res.valueRatio.denominator.value;
+    if (num != null && den != null) return num + ':' + den;
+  }
+  if (res.valueDateTime != null) return String(res.valueDateTime);
+  return null;
 }
 
 function summariseDiagnosticReport(res) {


### PR DESCRIPTION
## Summary

Closes #25. Adds a read-only `query_patient_history` tool to the decision-support (Feature C) agent loop so **history-dependent rules become actionable**. Previously the agent only saw pre-fetched prior `ServiceRequest`s, so rules like:

- "don't repeat HbA1c if one was resulted in the last 3 months" → Observation / DiagnosticReport
- "flag a test with no matching documented indication" → Condition
- "avoid this test while on medication X" → MedicationRequest

couldn't be evaluated. The agent now decides what to pull per rule, rather than the app pre-fetching a fixed set.

## Approach

A **thin local function** (no MCP server) reusing the existing authed `fetch` monkey-patch — works in headless/automated contexts where interactively-authed MCP servers may be absent.

**New module** `modules/patient-history-tool.js`:
- `getHistoryTools()` — the `query_patient_history` descriptor (`resourceType` enum + optional `code` / `category` / `dateFrom` / `count`).
- `makeHistoryToolImpl({ patientId })` — factory; the impl closes over the patient id and a private per-evaluation call counter.
- Summarises responses into compact per-type records (not raw FHIR) to limit prompt size / cost.

**Guardrails** (enforced in the impl, ignoring anything the model claims):
- read-only (GET only)
- resource-type allow-list: `Observation`, `Condition`, `MedicationRequest`, `DiagnosticReport`, `ServiceRequest`
- every query forced to `subject=Patient/{id}` — the model cannot widen scope
- `_count` capped (20)
- per-evaluation query budget (6)
- offered only when the patient is server-resolved; every query logged via `setDebugUrl` (debug panel, spec §C.12)

**Wiring** (`modules/ai-decision-support.js`): merges the tool into `tools`/`toolImpl` only when a patient id exists; adds a prompt paragraph on when to use it; bumps `maxIterations` 8→12 for the extra round-trips.

`dateFrom` maps to the per-resource clinical date param with a `_lastUpdated` fallback, mirroring the existing prior-requests `-authored`→`-_lastUpdated` pattern.

## Notes / tunables
- Limits are module constants (`ALLOWED_TYPES`, `MAX_COUNT`, `QUERY_BUDGET`) at the top of the new file — change there, no settings-UI churn.
- This PR delivers the **capability** only; history-dependent rules would be added to the guidelines text separately (pairs with the source-code-rules direction noted in the issue).

## Verification
Browser-only code, so no headless test of the agent loop. Manual walkthrough: server-resolved patient + notes + tests → Send → confirm `query_patient_history` GETs appear in the debug panel scoped to `subject=Patient/{id}` with capped `_count`; confirm budget cap halts further queries; non-allow-listed `resourceType` is rejected; query failures degrade silently and the send still proceeds. Both changed modules pass `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
