### PR TITLE
Improve generated coding prompts (schema, pre-search parsing, search strategy, demographics)

### DIFF
--- a/eRequest-placer-AI/modules/ai-context.js
+++ b/eRequest-placer-AI/modules/ai-context.js
@@ -46,14 +46,16 @@ export async function confirmInScope(candidate, ecl) {
 }
 
 /**
- * Combine the operator's COMMON guidance with a feature-specific guidance block
- * for injection into a system prompt. Returns '(none)' when both are empty so the
- * prompt slot is never left dangling. No branching — the caller passes only the
- * fields relevant to its feature.
+ * Build an operator-guidance block for injection into a system prompt: the given
+ * heading followed by the operator's COMMON guidance combined with a
+ * feature-specific block. Returns '' (not '(none)') when both are empty, so the
+ * caller can omit the section entirely rather than emit a placeholder the model
+ * might read as meaningful content. The caller passes only the fields relevant to
+ * its feature, and collapses the resulting blank run after substitution.
  */
-export function combineGuidance(commonText, specificText) {
+export function guidanceBlock(heading, commonText, specificText) {
   const parts = [String(commonText || '').trim(), String(specificText || '').trim()].filter(Boolean);
-  return parts.length ? parts.join('\n') : '(none)';
+  return parts.length ? heading + '\n' + parts.join('\n') : '';
 }
 
 export { SCT };

--- a/eRequest-placer-AI/modules/ai-decision-support.js
+++ b/eRequest-placer-AI/modules/ai-decision-support.js
@@ -10,22 +10,24 @@ import { state } from './state.js';
 import { getAiSettings, isDecisionSupportEnabled } from './settings-ai.js';
 import { runAgent } from './ai-agent.js';
 import { getTools, searchConcepts, lookupConcept } from './ontoserver-tools.js';
-import { gatherPatientContext, combineGuidance } from './ai-context.js';
+import { gatherPatientContext, guidanceBlock } from './ai-context.js';
 import { fetchAndSummarisePrior } from './prior-requests.js';
 import { getHistoryTools, makeHistoryToolImpl } from './patient-history-tool.js';
 
 const VALID_SEVERITY = new Set(['advisory', 'serious']);
 const VALID_DIMENSION = new Set(['appropriateness', 'suggestion', 'duplicate', 'context']);
 
-// Spec §C.7 (system prompt) + §C.8 (output format). {guidelines} is substituted
-// with the operator's COMMON + decision-support guidance (combineGuidance); it is
-// '(none)' when both are empty so the slot never dangles, and the feature then
-// runs on the model's general clinical training alone (spec §C.4).
+const GUIDELINES_HEADING = 'Apply the following clinical guidelines and local rules as authoritative where they conflict with your general training:';
+
+// Spec §C.7 (system prompt) + §C.8 (output format). {guidance_block} is the
+// operator's COMMON + decision-support guidance under GUIDELINES_HEADING, or ''
+// when both are empty — in which case the whole block is omitted (the surrounding
+// blank run is collapsed) and the feature runs on the model's general clinical
+// training alone (spec §C.4).
 const SYSTEM_PROMPT = [
   'You are a clinical decision support assistant for a general practice requesting clinician. You will be given a draft pathology or radiology request and must evaluate it across four dimensions: appropriateness, missed tests, duplicates, and context completeness.',
   '',
-  'Apply the following clinical guidelines and local rules as authoritative where they conflict with your general training:',
-  '{guidelines}',
+  '{guidance_block}',
   '',
   'For each finding, assign a severity:',
   '- "advisory" — informational, non-urgent; the clinician may proceed without action.',
@@ -78,9 +80,13 @@ export async function evaluateRequest(bundle) {
     const priorRequests = pid ? await fetchAndSummarisePrior(pid) : [];
 
     // Function replacer so a literal `$` in operator guidance isn't treated as a
-    // String.replace special pattern ($&, $1, …).
-    const guidance = combineGuidance(s.COMMON_PROMPT_SUPPLEMENTS, s.GUIDELINES_SUMMARY);
-    const systemPrompt = SYSTEM_PROMPT.replace('{guidelines}', () => guidance);
+    // String.replace special pattern ($&, $1, …). When there's no operator
+    // guidance the block is '' — collapse the resulting blank run.
+    const guidance = guidanceBlock(GUIDELINES_HEADING, s.COMMON_PROMPT_SUPPLEMENTS, s.GUIDELINES_SUMMARY);
+    const systemPrompt = SYSTEM_PROMPT
+      .replace('{guidance_block}', () => guidance)
+      .replace(/\n{3,}/g, '\n\n')
+      .trim();
 
     const userMessage = JSON.stringify({
       selected_tests: selectedTests,

--- a/eRequest-placer-AI/modules/ai-decision-support.js
+++ b/eRequest-placer-AI/modules/ai-decision-support.js
@@ -12,7 +12,22 @@ import { runAgent } from './ai-agent.js';
 import { getTools, searchConcepts, lookupConcept } from './ontoserver-tools.js';
 import { gatherPatientContext, guidanceBlock } from './ai-context.js';
 import { fetchAndSummarisePrior } from './prior-requests.js';
-import { getHistoryTools, makeHistoryToolImpl } from './patient-history-tool.js';
+import { getHistoryTools, makeHistoryToolImpl, QUERY_BUDGET } from './patient-history-tool.js';
+
+// Iteration cap for the decision-support agent. Derived from the history tool's
+// QUERY_BUDGET rather than a bare magic number: a free model that issues tool
+// calls sequentially (one per turn) spends one iteration per query, so the cap
+// must clear QUERY_BUDGET history queries PLUS headroom for a couple of optional
+// terminology lookups and the final-answer turn — otherwise runAgent returns the
+// iteration-cap error before the agent can use the history capability from #28
+// and decision support reports "unavailable". The history tool still enforces
+// QUERY_BUDGET itself as the real bound on fetching, so this cap is a safety
+// ceiling, not the limiter. (This supersedes fa5dd04's flat cap of 5, which was a
+// blunt rate-limit lever: capping a single run's burst against the free tier's
+// ~20/min. The right rate-limit control is client-side backoff/throttle — already
+// a single 429 retry in openrouter-client — or a paid key, not starving the
+// agent's iteration budget. A/B use a comparable 12; see ai-reason-coding.js.)
+const DECISION_MAX_ITERATIONS = QUERY_BUDGET + 4;
 
 const VALID_SEVERITY = new Set(['advisory', 'serious']);
 const VALID_DIMENSION = new Set(['appropriateness', 'suggestion', 'duplicate', 'context']);
@@ -116,13 +131,9 @@ export async function evaluateRequest(bundle) {
       tools,
       toolImpl,
       model: s.OPENROUTER_MODEL,
-      // Each iteration is one model request, so this caps the per-run request
-      // burst that was tripping OpenRouter's free-tier rate limit (~20/min).
-      // Lowered 12 -> 5 to ease that pressure. RE-EVALUATE if evaluations start
-      // failing with "did not produce a final answer within N iterations": that
-      // means 5 is too tight for the history-querying + terminology round-trips a
-      // complete answer needs, and it should be raised (8 was the prior default).
-      maxIterations: 5,
+      // Derived from the history QUERY_BUDGET (see DECISION_MAX_ITERATIONS above)
+      // so the iteration cap can't strand the #28 history capability.
+      maxIterations: DECISION_MAX_ITERATIONS,
     });
 
     if (error) return { result: null, error };

--- a/eRequest-placer-AI/modules/ai-reason-coding.js
+++ b/eRequest-placer-AI/modules/ai-reason-coding.js
@@ -81,6 +81,15 @@ export async function suggestReasonCodes() {
       tools: getTools(),
       toolImpl,
       model: s.OPENROUTER_MODEL,
+      // Headroom for the multi-term search strategy this prompt now asks for
+      // (>=2 searches per concept, rephrase-on-miss). Each iteration is one model
+      // request; a small/free model that issues tool calls sequentially (one per
+      // turn) can otherwise exhaust the default 8 on a multi-concept note and
+      // return the iteration-cap error -> empty suggestions, exactly the rich
+      // inputs this change is meant to help. 12 stays within a single run's
+      // free-tier rate budget (~20/min). (Feature C uses a tighter 5 because it
+      // bursts at Send alongside other calls; A/B are user-triggered in isolation.)
+      maxIterations: 12,
     });
 
     if (error) return { codes: [], error };

--- a/eRequest-placer-AI/modules/ai-reason-coding.js
+++ b/eRequest-placer-AI/modules/ai-reason-coding.js
@@ -9,21 +9,30 @@
 import { getAiSettings } from './settings-ai.js';
 import { runAgent } from './ai-agent.js';
 import { getTools, searchConcepts, lookupConcept } from './ontoserver-tools.js';
-import { gatherPatientContext, confirmInScope, combineGuidance, SCT } from './ai-context.js';
+import { gatherPatientContext, confirmInScope, guidanceBlock, SCT } from './ai-context.js';
 
-// Based on spec §4.5, with an added "Operator guidance" block (so not verbatim).
-// {reason_ecl} and {guidance} are substituted at call time.
+const GUIDANCE_HEADING = 'Operator guidance — apply any of the following that applies to this request:';
+
+// Based on spec §4.5/§4.6, extended (so not verbatim) with: an explicit element
+// schema, a pre-search parsing step, search-strategy guidance, demographic
+// disambiguation, and an "Operator guidance" block. {reason_ecl} and
+// {guidance_block} are substituted at call time; {guidance_block} is '' when the
+// operator set no guidance, and the surrounding blank run is then collapsed.
 const SYSTEM_PROMPT = [
   'You are a clinical coding assistant. Your task is to derive a minimal, accurate set of SNOMED CT codes representing the clinical meaning of a clinician\'s free-text notes.',
   '',
   'Prioritise accuracy over completeness. Return only codes you are confident are correct. Do not speculate. Do not use concept IDs from memory.',
   '',
-  'You have access to an Ontoserver MCP tool. Use `search_concepts` with the ECL expression `{reason_ecl}` to find and confirm every concept before including it. Only include a code if Ontoserver confirms it is valid, active, and within the ECL scope. If no match is found, omit the concept.',
+  'Before searching, identify each distinct clinical concept in the notes. For each, note your interpretation of any abbreviation, acronym, or apparent typo, and determine the preferred clinical terminology to search with. Use the patient age, sex, and pregnancy status to disambiguate where the meaning would differ across populations, and do not include concepts that are clinically inconsistent with those demographics.',
   '',
-  'Operator guidance — apply any of the following that applies to this request:',
-  '{guidance}',
+  'You have access to an Ontoserver MCP tool. For each concept, use `search_concepts` with the ECL expression `{reason_ecl}` to find and confirm it before including it. Try at least two search terms — a lay phrasing and a formal clinical equivalent — and if the first search returns nothing useful, rephrase using formal clinical terminology. Prefer the most specific valid concept that accurately reflects the clinical text; do not broaden to a parent concept unless no specific match exists. Only include a code if Ontoserver confirms it is valid, active, and within the ECL scope. The ECL scope is intentionally limited (typically to clinical findings and disorders); if a concept falls outside it or has no valid match, omit that concept.',
   '',
-  'Return a JSON array only, no prose or markdown formatting.',
+  '{guidance_block}',
+  '',
+  'Return a JSON array only (an empty array if no codes can be confidently derived), with no prose or markdown formatting. Each element must be an object with these keys:',
+  '- "code": string — the SNOMED CT concept ID confirmed by Ontoserver',
+  '- "display": string — the preferred term exactly as returned by Ontoserver, not paraphrased',
+  '- "system": string — always "http://snomed.info/sct"',
 ].join('\n');
 
 function gatherContext() {
@@ -49,11 +58,15 @@ export async function suggestReasonCodes() {
     }
 
     // Function replacers so a literal `$` in operator guidance / ECL isn't treated
-    // as a String.replace special pattern ($&, $1, …).
-    const guidance = combineGuidance(s.COMMON_PROMPT_SUPPLEMENTS, s.REASON_PROMPT_SUPPLEMENTS);
+    // as a String.replace special pattern ($&, $1, …). When there's no operator
+    // guidance the block is '' — collapse the resulting blank run so the prompt
+    // doesn't carry a dangling gap.
+    const guidance = guidanceBlock(GUIDANCE_HEADING, s.COMMON_PROMPT_SUPPLEMENTS, s.REASON_PROMPT_SUPPLEMENTS);
     const systemPrompt = SYSTEM_PROMPT
       .replace('{reason_ecl}', () => reasonEcl)
-      .replace('{guidance}', () => guidance);
+      .replace('{guidance_block}', () => guidance)
+      .replace(/\n{3,}/g, '\n\n')
+      .trim();
     const userMessage = JSON.stringify(ctx);
 
     // search_concepts is hard-coerced to REASON_ECL no matter what the model passes.

--- a/eRequest-placer-AI/modules/ai-test-selection.js
+++ b/eRequest-placer-AI/modules/ai-test-selection.js
@@ -96,6 +96,10 @@ export async function suggestTests() {
       tools: getTools(),
       toolImpl,
       model: s.OPENROUTER_MODEL,
+      // See ai-reason-coding.js: same multi-term search strategy, same need for
+      // headroom over the default 8 so a sequential-calling free model doesn't hit
+      // the iteration cap on a multi-test request and return nothing.
+      maxIterations: 12,
     });
 
     if (error) return { tests: [], error };

--- a/eRequest-placer-AI/modules/ai-test-selection.js
+++ b/eRequest-placer-AI/modules/ai-test-selection.js
@@ -11,24 +11,27 @@ import { state } from './state.js';
 import { getAiSettings } from './settings-ai.js';
 import { runAgent } from './ai-agent.js';
 import { getTools, searchConcepts, lookupConcept } from './ontoserver-tools.js';
-import { gatherPatientContext, confirmInScope, combineGuidance, SCT } from './ai-context.js';
+import { gatherPatientContext, confirmInScope, guidanceBlock, SCT } from './ai-context.js';
+
+const GUIDANCE_HEADING = 'Operator guidance — apply any of the following that applies to this request:';
 
 // Based on spec §5.6 (not verbatim): the §5.6 "default assumptions" line is
-// generalised to an "Operator guidance" block ({guidance}); {test_ecl} is also
-// substituted; and the §5.7 output shape is extended with a `kind` field (PATH/IMAG).
+// generalised to an "Operator guidance" block ({guidance_block}, omitted when the
+// operator set none); {test_ecl} is substituted; the §5.7 output shape is extended
+// with a `kind` field (PATH/IMAG); and — mirroring Feature A — a pre-search parsing
+// step, search-strategy guidance, and demographic disambiguation are added.
 const SYSTEM_PROMPT = [
   'You are a clinical test coding assistant. Your task is to derive a set of SNOMED CT procedure codes representing the diagnostic tests described in the clinician\'s free-text input.',
   '',
-  'Operator guidance — apply any of the following that applies to this request:',
-  '{guidance}',
-  '',
   'Prioritise accuracy over completeness. Do not speculate. Do not use concept IDs from memory.',
   '',
-  'You have access to an Ontoserver MCP tool. Use `search_concepts` with the ECL expression `{test_ecl}` to find and confirm every concept. Only include a code if Ontoserver confirms it is valid, active, and within the ECL scope. If no match is found, omit the concept.',
+  'Before searching, identify each distinct test described in the input. For each, note your interpretation of any abbreviation, acronym, or apparent typo, and determine the preferred clinical terminology to search with. Use the patient age, sex, and pregnancy status to disambiguate where the meaning would differ across populations, and do not include tests that are clinically inconsistent with those demographics. Do not re-add a test that is already selected.',
   '',
-  'Each array element must be an object with keys "code", "display", "system" (always "http://snomed.info/sct"), and "kind" — "PATH" for pathology/laboratory tests or "IMAG" for imaging/radiology. If unsure, use "PATH".',
+  'You have access to an Ontoserver MCP tool. For each test, use `search_concepts` with the ECL expression `{test_ecl}` to find and confirm it. Try at least two search terms — a lay phrasing and a formal clinical equivalent — and if the first search returns nothing useful, rephrase using formal clinical terminology. Prefer the most specific valid concept that accurately reflects the requested test; do not broaden to a parent concept unless no specific match exists. Only include a code if Ontoserver confirms it is valid, active, and within the ECL scope. If a test falls outside the scope or has no valid match, omit it.',
   '',
-  'Return a JSON array only, no prose or markdown formatting.',
+  '{guidance_block}',
+  '',
+  'Return a JSON array only (an empty array if no tests can be confidently derived), with no prose or markdown formatting. Each element must be an object with keys "code" (the confirmed SNOMED CT concept ID), "display" (the preferred term exactly as returned by Ontoserver), "system" (always "http://snomed.info/sct"), and "kind" — "PATH" for pathology/laboratory tests or "IMAG" for imaging/radiology. If unsure, use "PATH".',
 ].join('\n');
 
 // Map a model-supplied kind to PATH/IMAG. The prompt constrains output to those
@@ -72,11 +75,14 @@ export async function suggestTests() {
     });
 
     // Function replacers so a literal `$` in operator guidance / ECL isn't treated
-    // as a String.replace special pattern ($&, $1, …).
-    const guidance = combineGuidance(s.COMMON_PROMPT_SUPPLEMENTS, s.PRE_PROMPT_SUPPLEMENTS);
+    // as a String.replace special pattern ($&, $1, …). When there's no operator
+    // guidance the block is '' — collapse the resulting blank run.
+    const guidance = guidanceBlock(GUIDANCE_HEADING, s.COMMON_PROMPT_SUPPLEMENTS, s.PRE_PROMPT_SUPPLEMENTS);
     const systemPrompt = SYSTEM_PROMPT
-      .replace('{guidance}', () => guidance)
-      .replace('{test_ecl}', () => testEcl);
+      .replace('{guidance_block}', () => guidance)
+      .replace('{test_ecl}', () => testEcl)
+      .replace(/\n{3,}/g, '\n\n')
+      .trim();
 
     // search_concepts is hard-coerced to TEST_ECL no matter what the model passes.
     const toolImpl = {

--- a/eRequest-placer-AI/modules/patient-history-tool.js
+++ b/eRequest-placer-AI/modules/patient-history-tool.js
@@ -32,7 +32,10 @@ const MAX_COUNT = 20;
 
 // Per-evaluation ceiling on the number of history queries the agent may make.
 // Bounds prompt size / latency / cost of agent-initiated fetching (issue #25).
-const QUERY_BUDGET = 6;
+// Exported so the decision-support agent's maxIterations can be derived from it —
+// the iteration cap must leave room for this many queries plus the final answer,
+// or the history capability is stranded (see ai-decision-support.js).
+export const QUERY_BUDGET = 6;
 
 // Per-resource clinical date search parameter for the optional `dateFrom` filter.
 // Falls back to the universal `_lastUpdated` if the server rejects the clinical


### PR DESCRIPTION
Closes #29.

Strengthens the system prompts the app builds for the AI coding features so the model parses, searches, and labels concepts more reliably. All changes are prompt-string + assembly only — no parser, UI, or FHIR-bundle changes.

## What changed

**Feature A — reason coding** ([ai-reason-coding.js](eRequest-placer-AI/modules/ai-reason-coding.js))
- **Explicit JSON schema** (issue item 1): each element must be `code` / `display` / `system`, using the field names the existing parser already keys on ([ai-reason-coding.js:87-90](eRequest-placer-AI/modules/ai-reason-coding.js#L87-L90)) and matching spec §4.6. `display` is pinned to "exactly as returned by Ontoserver, not paraphrased" so the model can't hallucinate a label after fetching the right ID.
- **Pre-search parsing step** (item 2): identify each concept and resolve abbreviations/typos to clinical terminology before searching.
- **Search-strategy guidance** (item 3): try a lay + a formal term, rephrase on a miss, prefer the most specific in-scope concept.
- **Demographics** (item 4): disambiguate by age/sex/pregnancy; drop concepts clinically inconsistent with them.
- **ECL-scope note** (item 6): states the scope is intentionally bounded (findings/disorders), so the model treats out-of-scope omissions as expected.

**Feature B — test selection** ([ai-test-selection.js](eRequest-placer-AI/modules/ai-test-selection.js)): already carried the schema + `kind` field, so this mirrors the parsing / search-strategy / demographic guidance onto it.

**All three features — empty operator-guidance block** (item 5): `combineGuidance` previously emitted a literal `(none)` the model could read as content. Replaced with `guidanceBlock(heading, common, specific)` in [ai-context.js](eRequest-placer-AI/modules/ai-context.js), which returns the heading + guidance or `''`; callers collapse the blank run (`/\n{3,}/g → \n\n`) so an unset block is omitted entirely. Applied to Feature C decision support as well.

## Out of scope (left noted on #29)
- **`sourceText` field** — useful for traceability but the parser/UI don't consume it; adding it needs parser + UI work.
- **Null-match "gap" convention** (item 7) — conflicts with the parser's drop-on-missing-`code` filter and the in-scope re-confirmation; needs a design decision before building.

## Verification
- `node --check` passes on all four modules; no stale `combineGuidance` / `{guidance}` / `{guidelines}` references remain.
- Rendered the templates with empty and populated guidance to confirm the blank-run collapse leaves no dangling block.
- No automated test harness in this app; prompt behaviour is best confirmed in the end-of-phases live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
